### PR TITLE
:sparkles: WFP-627: add primary nav

### DIFF
--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -1,2 +1,5 @@
 .govuk-main-wrapper
   min-height: 600px
+
+.maw-no-border
+  border-bottom: none

--- a/integration_tests/integration/unallocated.spec.ts
+++ b/integration_tests/integration/unallocated.spec.ts
@@ -27,6 +27,19 @@ context('Unallocated', () => {
     unallocatedPage.probationDeliveryUnit().should('contain.text', 'Gateshead and South Tyneside')
   })
 
+  it('Primary nav visible on page', () => {
+    cy.signIn()
+    const unallocatedPage = Page.verifyOnPage(UnallocatedPage)
+    unallocatedPage
+      .primaryNav()
+      .should('contain', 'Allocations')
+      .and('contain', 'Offender Management')
+      .and('contain', 'OMIC')
+      .and('contain', 'Courts')
+      .and('contain', 'Expiring Reductions')
+      .and('contain', 'Search')
+  })
+
   it('User can log out', () => {
     cy.signIn()
     const unallocatedPage = Page.verifyOnPage(UnallocatedPage)

--- a/integration_tests/pages/unallocated.ts
+++ b/integration_tests/pages/unallocated.ts
@@ -6,4 +6,6 @@ export default class UnallocatedPage extends Page {
   }
 
   probationDeliveryUnit = (): PageElement => cy.get('.govuk-caption-xl')
+
+  primaryNav = (): PageElement => cy.get('ul.moj-primary-navigation__list').children()
 }

--- a/server/views/components/primary-nav/macro.njk
+++ b/server/views/components/primary-nav/macro.njk
@@ -1,0 +1,3 @@
+{% macro mawPrimaryNav(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/server/views/components/primary-nav/template.njk
+++ b/server/views/components/primary-nav/template.njk
@@ -1,0 +1,46 @@
+<div class="moj-primary-navigation">
+
+    <div class="moj-primary-navigation__container">
+
+        <div class="moj-primary-navigation__nav">
+
+            <nav class="moj-primary-navigation" aria-label="Primary navigation">
+
+                <ul class="moj-primary-navigation__list">
+
+                    <li class="moj-primary-navigation__item">
+                        <a class="moj-primary-navigation__link" aria-current="page"
+                           href="/"> {% if params.data.allocations %}
+                                <span id="notifications" style="display: inline-block;"
+                                      class="moj-notification-badge">{{ params.data.allocations | length }}</span>
+                                     {% endif %}
+                            Allocations</a>
+                    </li>
+
+                    <li class="moj-primary-navigation__item">
+                        <a class="moj-primary-navigation__link" href="/">Offender Management</a>
+                    </li>
+
+                    <li class="moj-primary-navigation__item">
+                        <a class="moj-primary-navigation__link" href="/">OMIC</a>
+                    </li>
+
+                    <li class="moj-primary-navigation__item">
+                        <a class="moj-primary-navigation__link" href="/">Courts</a>
+                    </li>
+
+                    <li class="moj-primary-navigation__item">
+                        <a class="moj-primary-navigation__link" href="/">Expiring Reductions</a>
+                    </li>
+
+                    <li class="moj-primary-navigation__item">
+                        <a class="moj-primary-navigation__link" href="/">Search</a>
+                    </li>
+                </ul>
+
+            </nav>
+
+        </div>
+    </div>
+
+</div>

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -1,49 +1,106 @@
-{% extends "govuk/template.njk" %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+<!DOCTYPE html>
+<html lang="en" class="govuk-template no-js">
+<head>
 
-{% block head %}
-  <!--[if !IE 8]><!-->
-  <link href="/assets/stylesheets/application.css?{{ version }}" rel="stylesheet"/>
-  <!--<![endif]-->
+    {%- from "components/primary-nav/macro.njk" import mawPrimaryNav -%}
 
-  <!--[if lt IE 9]>
-  <link href="/assets/stylesheets/application-ie8.css?{{ version }}" rel="stylesheet"/>
-  <script src="/assets/js/html5shiv-3.7.3.min.js"></script>
-  <![endif]-->
+    {% set mainTitle = "Allocations" %}
 
-  <script src="/assets/js/jquery.min.js"></script> 
-  <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"
-          integrity="sha256-VazP97ZCwtekAsvgPBSUwPFKdrwD3unUfSGVYrahUqU="
-          crossorigin="anonymous"></script>
-  <link href="https://code.jquery.com/ui/1.12.1/themes/ui-lightness/jquery-ui.css" rel="stylesheet">
+    {% block head %}
+        <meta charset="utf-8"/>
 
-{% endblock %}
+        <title>{{ title }} - {{ mainTitle }}</title>
 
-{% block pageTitle %}{{pageTitle | default(applicationName)}}{% endblock %}
+        <!--[if !IE 8]><!-->
+        <link href="/assets/stylesheets/application.css?{{ version }}" rel="stylesheet"/>
+        <!--<![endif]-->
 
+        <!--[if lt IE 9]>
+        <link href="/assets/stylesheets/application-ie8.css?{{ version }}" rel="stylesheet"/>
+        <script src="/assets/js/html5shiv-3.7.3.min.js"></script>
+        <![endif]-->
 
-{% block header %}
-  {% include "./header.njk" %}
-  
-{% endblock %}
+        <script src="/assets/js/jquery.min.js"></script>
+        <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"
+                integrity="sha256-VazP97ZCwtekAsvgPBSUwPFKdrwD3unUfSGVYrahUqU="
+                crossorigin="anonymous"></script>
+        <link href="https://code.jquery.com/ui/1.12.1/themes/ui-lightness/jquery-ui.css" rel="stylesheet">
 
+    {% endblock %}
+</head>
+<body class="govuk-template__body">
 
-{% block beforeContent %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "beta"
-  },
-  html: 'This is a new service – your <a class="govuk-link" href="https://teams.microsoft.com/l/team/19%3afPYHTv_Z06KQ-wPz3oc2kLLhVKDypOtLeyXOpoXM85w1%40thread.tacv2/conversations?groupId=0f8c1490-bf11-4ba6-a889-6438b082c3f8&tenantId=c6874728-71e6-41fe-a9e1-2e8c36776ad8">feedback</a> will help us to improve it.'
-}) }}
-{% endblock %}
+<script>
+    document.body.classList.add('js-enabled')
+</script>
+
+<a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 
 {% block bodyStart %}
+
 {% endblock %}
 
-{% block bodyEnd %}
-  {# Run JavaScript at end of the
-  <body>, to avoid blocking the initial render. #}
-  <script src="/assets/govuk/all.js"></script>
-  <script src="/assets/govukFrontendInit.js"></script>
-  <script src="/assets/moj/all.js"></script>
+{% block header %}
+    {% include "./header.njk" %}
 {% endblock %}
+
+{% block phaseBanner %}
+    <div class="govuk-width-container">
+        {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+        {{ govukPhaseBanner({
+            tag: {
+                text: "beta"
+            },
+            classes: 'maw-no-border',
+            html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+        }) }}
+    </div>
+{% endblock %}
+
+{% block navigation %}
+    {{ mawPrimaryNav({data: data}) }}
+{% endblock %}
+
+
+<nav class="govuk-width-container" aria-label="Backwards navigation">
+    {% block backlink %}{% endblock %}
+</nav>
+
+<div class="govuk-width-container">
+    <main class="govuk-main-wrapper" id="main-content" role="main">
+        {% block content %}{% endblock %}
+    </main>
+</div>
+
+{% block footer %}
+    {%- from "govuk/components/footer/macro.njk" import govukFooter -%}
+    {{ govukFooter({
+        meta: {
+            items: [
+                {
+                    href: "/",
+                    text: "Accessibility statement"
+                },
+                {
+                    href: "/",
+                    text: "Cookies"
+                },
+                {
+                    href: "/",
+                    text: "Privacy"
+                }
+            ]
+        }
+    }) }}
+{% endblock %}
+
+{% block javascripts %}{% endblock %}
+
+{% block bodyEnd %}
+    <script src="/assets/govuk/all.js"></script>
+    <script src="/assets/govukFrontendInit.js"></script>
+    <script src="/assets/moj/all.js"></script>
+{% endblock %}
+
+</body>
+</html>


### PR DESCRIPTION
- We are unable to extend from the gov template.njk due to the blocks available. Template.njk has a structure of block main that contains  blocks beforeContent and content. We previously put the phase banner in beforeContent and this worked well, however the primary nav sits below the phase banner and fits full length of the screen, so this won't work. We had the same issue in prepare-a-case. See https://design-system.service.gov.uk/styles/page-template/ for more info regarding the gov page template.
- For the primary nav component, I have used the HTML code rather than nunjucks due to inserting the notification badge into the nav. I have separated this out into a macro.
- I've removed the bottom border of the phase banner as I noticed this wasn't visible on the prototype
- I've added the footer links to cookies, privacy and accessibility statement, but we'll need to add the required pages at some point