### PR TITLE
Wfp 625 footer component

### DIFF
--- a/integration_tests/integration/unallocated.spec.ts
+++ b/integration_tests/integration/unallocated.spec.ts
@@ -119,4 +119,16 @@ context('Unallocated', () => {
     const authPage = new AuthSignInPage()
     authPage.checkOnPage()
   })
+
+  it('Footer visible on page', () => {
+    cy.signIn()
+    const unallocatedPage = Page.verifyOnPage(UnallocatedPage)
+    unallocatedPage
+      .footer()
+      .should('contain', 'Accessibility statement')
+      .and('contain', 'Cookies')
+      .and('contain', 'Privacy')
+      .and('contain', 'Open Government Licence v3.0')
+      .and('contain', '© Crown copyright')
+  })
 })

--- a/integration_tests/pages/unallocated.ts
+++ b/integration_tests/pages/unallocated.ts
@@ -26,4 +26,6 @@ export default class UnallocatedPage extends Page {
   otherCasesInset = (): PageElement => cy.get('div.govuk-inset-text')
 
   notificationsBadge = (): PageElement => cy.get('.moj-notification-badge')
+
+  footer = (): PageElement => cy.get('.govuk-footer ')
 }

--- a/server/app.ts
+++ b/server/app.ts
@@ -17,6 +17,7 @@ import setUpHealthChecks from './middleware/setUpHealthChecks'
 import setUpWebRequestParsing from './middleware/setupRequestParsing'
 import authorisationMiddleware from './middleware/authorisationMiddleware'
 import AllocationsService from './services/allocationsService'
+import unauthenticatedRoutes from './routes/unauthenticated'
 
 export default function createApp(
   userService: UserService,
@@ -35,6 +36,7 @@ export default function createApp(
   app.use(setUpStaticResources())
   nunjucksSetup(app, path)
   app.use(setUpAuthentication())
+  app.use(unauthenticatedRoutes())
   app.use(authorisationMiddleware(['ROLE_MANAGE_A_WORKFORCE_ALLOCATE']))
 
   app.use(

--- a/server/errorHandler.test.ts
+++ b/server/errorHandler.test.ts
@@ -1,6 +1,6 @@
 import type { Express } from 'express'
 import request from 'supertest'
-import appWithAllRoutes from './routes/testutils/appSetup'
+import { appWithAllRoutes } from './routes/testutils/appSetup'
 
 let app: Express
 

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -17,5 +17,17 @@ export default function routes(router: Router, services: Services): Router {
     allocationsController.getAllocations(req, res)
   })
 
+  get('/accessibility-statement', (req, res) => {
+    res.render('pages/accessibility-statement')
+  })
+
+  get('/privacy-notice', (req, res) => {
+    res.render('pages/privacy-notice')
+  })
+
+  get('/cookie-policy', (req, res) => {
+    res.render('pages/cookie-policy')
+  })
+
   return router
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -17,17 +17,5 @@ export default function routes(router: Router, services: Services): Router {
     allocationsController.getAllocations(req, res)
   })
 
-  get('/accessibility-statement', (req, res) => {
-    res.render('pages/accessibility-statement')
-  })
-
-  get('/privacy-notice', (req, res) => {
-    res.render('pages/privacy-notice')
-  })
-
-  get('/cookie-policy', (req, res) => {
-    res.render('pages/cookie-policy')
-  })
-
   return router
 }

--- a/server/routes/unauthenticated/accessibility.test.ts
+++ b/server/routes/unauthenticated/accessibility.test.ts
@@ -1,0 +1,20 @@
+import request from 'supertest'
+import { appWithAllRoutes } from '../testutils/appSetup'
+
+describe('GET Accessibility', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('GET Accessibility statement', () => {
+    test("should render the 'Accessibility statement' page", () => {
+      return request(appWithAllRoutes({ production: false }))
+        .get(`/accessibility-statement`)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.status).toBe(200)
+          expect(res.text).toContain('Accessibility statement for Manage a workforce')
+        })
+    })
+  })
+})

--- a/server/routes/unauthenticated/accessibility.ts
+++ b/server/routes/unauthenticated/accessibility.ts
@@ -1,0 +1,7 @@
+import type { Request, Response } from 'express'
+
+export default function Accessibility() {
+  return (req: Request, res: Response): void => {
+    res.render(`pages/accessibility-statement`)
+  }
+}

--- a/server/routes/unauthenticated/cookies.test.ts
+++ b/server/routes/unauthenticated/cookies.test.ts
@@ -1,0 +1,20 @@
+import request from 'supertest'
+import { appWithAllRoutes } from '../testutils/appSetup'
+
+describe('GET Cookies', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('GET Cookie policy', () => {
+    test("should render the 'Cookie policy' page", () => {
+      return request(appWithAllRoutes({ production: false }))
+        .get(`/cookie-policy`)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.status).toBe(200)
+          expect(res.text).toContain('Cookies')
+        })
+    })
+  })
+})

--- a/server/routes/unauthenticated/cookies.ts
+++ b/server/routes/unauthenticated/cookies.ts
@@ -1,0 +1,7 @@
+import type { Request, Response } from 'express'
+
+export default function Cookies() {
+  return (req: Request, res: Response): void => {
+    res.render(`pages/cookie-policy`)
+  }
+}

--- a/server/routes/unauthenticated/index.ts
+++ b/server/routes/unauthenticated/index.ts
@@ -1,0 +1,16 @@
+import express, { Router } from 'express'
+import asyncMiddleware from '../../middleware/asyncMiddleware'
+
+import Accessibility from './accessibility'
+import Privacy from './privacy'
+import Cookies from './cookies'
+
+export default function UnauthenticatedRoutes(): Router {
+  const router = express.Router()
+
+  router.get('/accessibility-statement', asyncMiddleware(Accessibility()))
+  router.get('/privacy-notice', asyncMiddleware(Privacy()))
+  router.get('/cookie-policy', asyncMiddleware(Cookies()))
+
+  return router
+}

--- a/server/routes/unauthenticated/privacy.test.ts
+++ b/server/routes/unauthenticated/privacy.test.ts
@@ -1,0 +1,20 @@
+import request from 'supertest'
+import { appWithAllRoutes } from '../testutils/appSetup'
+
+describe('GET Privacy', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('GET Privacy notice', () => {
+    test("should render the 'Privacy notice' page", () => {
+      return request(appWithAllRoutes({ production: false }))
+        .get(`/privacy-notice`)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.status).toBe(200)
+          expect(res.text).toContain('Privacy notice')
+        })
+    })
+  })
+})

--- a/server/routes/unauthenticated/privacy.ts
+++ b/server/routes/unauthenticated/privacy.ts
@@ -1,0 +1,7 @@
+import type { Request, Response } from 'express'
+
+export default function Privacy() {
+  return (req: Request, res: Response): void => {
+    res.render(`pages/privacy-notice`)
+  }
+}

--- a/server/views/pages/accessibility-statement.njk
+++ b/server/views/pages/accessibility-statement.njk
@@ -1,0 +1,132 @@
+{% extends "partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - Accessibility statement" %}
+
+{% block navigation %}{% endblock %}
+
+{% block backlink %}
+    {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+    {{ govukBackLink({
+        text: "Back",
+        href: "/"
+    }) }}
+{% endblock %}
+
+{% block content %}
+    {% block content %}
+        <div class="govuk-grid-row">
+
+            <div class="govuk-grid-column-two-thirds">
+                <h1 class="govuk-heading-xl">Accessibility statement for Manage a workforce</h1>
+            </div>
+
+        </div>
+        <div class="govuk-grid-row">
+
+            <div class="govuk-grid-column-two-thirds">
+                <p>This page only contains information about the Manage a workforce service, available at <a
+                            href="https://manage-a-workforce.service.justice.gov.uk/">https://manage-a-workforce.service.justice.gov.uk/</a>
+                </p>
+
+                <h2 id="using" class="govuk-heading-l">Using this service</h2>
+                <p>This service is run by HMPPS Digital Services. We want as many people as possible to be able to use
+                    this service.</p>
+                <p>For example, that means you should be able to:
+
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>change colours, contrast levels and fonts</li>
+                    <li>zoom in up to 300% without the text spilling off the screen</li>
+                    <li>get from the start of the service to the end using just a keyboard</li>
+                    <li>get from the start of the service to the end using speech recognition software</li>
+                    <li>listen to the service using a screen reader (including the most recent versions of JAWS, NVDA
+                        and VoiceOver)
+                    </li>
+                </ul>
+                </p>
+
+                <p>We’ve also made the text in the service as simple as possible to understand.</p>
+
+                <p><a href="https://mcmw.abilitynet.org.uk/">AbilityNet</a> has advice on making your device easier to
+                    use if you have a disability.</p>
+
+                <h2 id="how-accessible" class="govuk-heading-l">How accessible this service is</h2>
+                <p>We know some parts of this service are not fully accessible:
+
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>list main examples of non-accessible parts of service e.g
+                        some documents are in PDF or other non-HTML formats
+                    </li>
+                </ul>
+
+                <h2 id="feedback" class="govuk-heading-l">Feedback and contact information</h2>
+                <p>If you have difficulty using this service, email: <a
+                            href="mailto:manageaworkforce@digital.justice.gov.uk">manageaworkforce@digital.justice.gov.uk</a>
+                </p>
+
+                <p>As part of providing this service, we may need to send you messages or documents. We’ll ask you how
+                    you want us to send messages or documents to you, but contact us if you need them in a different
+                    format. For example large print, audio recording or braille.</p>
+
+                <h2 id="reporting" class="govuk-heading-l">Reporting accessibility problems with this service</h2>
+                <p>We’re always looking to improve the accessibility of this service.</p>
+                <p>If you find any problems that are not listed on this page or think we’re not meeting accessibility
+                    requirements, email: <a href="mailto:manageaworkforce@digital.justice.gov.uk">manageaworkforce@digital.justice.gov.uk</a>
+                </p>
+
+                <h2 id="enforcement" class="govuk-heading-l">Enforcement procedure</h2>
+                <p>The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies
+                    (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility
+                    regulations’).</p>
+                <p>If you’re not happy with how we respond to your complaint, <a
+                            href="https://www.equalityadvisoryservice.com/">contact the Equality Advisory and Support
+                        Service (EASS)</a></p>
+
+                <h2 id="technical" class="govuk-heading-l">Technical information about this service’s accessibility</h2>
+                <p>HMPPS Digital Services is committed to making this service accessible, in accordance with the Public
+                    Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
+
+                <h3 class="govuk-heading-m">Compliance status</h3>
+                <p>This service is partially compliant with the <a href="https://www.w3.org/TR/WCAG21/">Web Content
+                        Accessibility Guidelines version 2.1 AA standard</a>, due to the non-compliances listed below.
+                </p>
+
+                <h2 id="content" class="govuk-heading-l">Non accessible content</h2>
+                <p>The content listed below is non-accessible for the following reasons.</p>
+
+                <h3 class="govuk-heading-m">Non-compliance with the accessibility regulations</h3>
+                <p>Explain the accessibility issue. State and link to the WCAG Guidelines that relate to the issue. Give
+                    a date when the issue will be fixed by.</p>
+                <p>PDFs and other documents are not accessible in a number of ways including missing text alternatives
+                    and missing document structure. This fails <a href="https://www.w3.org/TR/WCAG21/#non-text-content">WCAG
+                        1.1.1 A (Non-text Content) and WCAG 2.4.2 A (Page Titled)</a>. This issue will be fixed by 1
+                    January 2022.</p>
+
+                <h3 class="govuk-heading-m">Disproportionate burden</h3>
+                <p>Not applicable.</p>
+
+                <h3 class="govuk-heading-m">Content that’s not within the scope of the accessibility regulations</h3>
+                <p>Not applicable.</p>
+
+                <h2 id="improve" class="govuk-heading-l">What we are doing to improve accessibility</h2>
+
+                <p>We’ll carry out on-going internal audits to check the accessibility of this service as well as taking
+                    feedback from users.</p>
+
+                <p>Any required changes will be planned into our continuous improvement work for this service.</p>
+
+                <p>This accessibility statement will be updated based on any issues we identify or any changes we make
+                    to address any issues raised.</p>
+
+                <h2 id="preparation" class="govuk-heading-l">Preparation of this accessibility statement</h2>
+
+                <p>This statement was prepared on 11th November 2021. It was last reviewed on 11th November 2021.</p>
+
+                <p>This service was last tested on [DATE]. The test was carried out by the [Ministry of Justice
+                    Assistive Technology Support Team].</p>
+
+                <p class="govuk-body-s secondary-text-col">Last updated: 11th November 2021</p>
+
+            </div>
+        </div>
+
+    {% endblock %}

--- a/server/views/pages/accessibility-statement.njk
+++ b/server/views/pages/accessibility-statement.njk
@@ -13,7 +13,6 @@
 {% endblock %}
 
 {% block content %}
-    {% block content %}
         <div class="govuk-grid-row">
 
             <div class="govuk-grid-column-two-thirds">

--- a/server/views/pages/cookie-policy.njk
+++ b/server/views/pages/cookie-policy.njk
@@ -1,0 +1,23 @@
+{% extends "partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - Cookie policy" %}
+
+
+{% block navigation %}{% endblock %}
+
+{% block backlink %}
+    {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+    {{ govukBackLink({
+        text: "Back",
+        href: "/"
+    }) }}
+{% endblock %}
+{% block content %}
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-l">Cookies</h1>
+            <p class="govuk-body">Under construction.</p>
+        </div>
+    </div>
+{% endblock %}

--- a/server/views/pages/privacy-notice.njk
+++ b/server/views/pages/privacy-notice.njk
@@ -51,7 +51,7 @@
                 <li>your email address</li>
             </ul>
 
-            This data can be viewed by authorised people in HMPPS Digital Services and our suppliers, to:
+            <p class="govuk-body">This data can be viewed by authorised people in HMPPS Digital Services and our suppliers, to:</p>
 
             <ul class="govuk-list govuk-list--bullet">
                 <li>gather feedback to improve our services</li>

--- a/server/views/pages/privacy-notice.njk
+++ b/server/views/pages/privacy-notice.njk
@@ -1,0 +1,190 @@
+{% extends "partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - Privacy notice" %}
+
+{% block navigation %}{% endblock %}
+
+{% block backlink %}
+    {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+    {{ govukBackLink({
+        text: "Back",
+        href: "/"
+    }) }}
+
+{% endblock %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-xl">Privacy notice</h1>
+
+        </div>
+    </div>
+
+    <div class="govuk-grid-row">
+
+        <div class="govuk-grid-column-two-thirds">
+
+
+            <p>Manage a workforce (<a href="https://workforce-management.hmpps.service.justice.gov.uk/">https://workforce-management.hmpps.service.justice.gov.uk/</a>)
+                is provided by HMPPS Digital Services, part of the Ministry of Justice (MoJ).</p>
+
+            <p>This privacy notice sets out the standards that you can expect from the Ministry of Justice when we request or hold personal information (‘personal data’) about you; how you can get access to a copy of your personal data; and what you can do if you think the standards are not being met.</p>
+
+            <p>HMPPS Digital Services is part of HMPPS, an Executive Agency of the MoJ. MoJ is the data controller for the personal information we hold. HMPPS Digital Services collects and processes personal data for the exercise of its own and associated public functions. These include providing digital services to prison and probation staff.</p>
+
+            <h2 class="govuk-heading-l">About personal information</h2>
+            <p>Personal data is information about you as an individual. It can be your name, address or telephone number. It can also include information about where you work, your email address and your job title.</p>
+
+            <p>We know how important it is to protect customers’ privacy and to comply with data protection laws. We will safeguard your personal data and will only disclose it where it is lawful to do so, or with your consent.</p>
+
+            <h2 class="govuk-heading-l">What data we collect</h2>
+
+            <p>We collect certain information and data about you when you use Manage a workforce.
+                We collect:
+
+            <ul class="govuk-list govuk-list--bullet">
+                <li>your name and username</li>
+                <li>the cases you access on the service</li>
+                <li>your IP address</li>
+                <li>your email address</li>
+            </ul>
+
+            This data can be viewed by authorised people in HMPPS Digital Services and our suppliers, to:
+
+            <ul class="govuk-list govuk-list--bullet">
+                <li>gather feedback to improve our services</li>
+                <li>respond to any feedback you send us, if you’ve asked us to</li>
+            </ul>
+
+            <p>We use Google Analytics software to collect information about how you use Manage a workforce. This includes IP addresses. The data is anonymised before being used for analytics processing.</p>
+
+            <p>Google Analytics processes anonymised information about:
+            <ul class="govuk-list govuk-list--bullet">
+                <li>the pages you visit on Manage a workforce</li>
+                <li>how long you spend on each page</li>
+                <li>how you got to the service</li>
+                <li>what you click on while you’re using the service</li>
+            </ul>
+            </p>
+
+            <p>We do not store your personal information through Google Analytics (for example your name or address).</p>
+
+            <p>We will not identify you through analytics information, and we will not combine analytics information with other data sets in a way that would identify who you are.</p>
+
+            <p>We continuously test and monitor our data protection controls to make sure they’re effective and to detect any weaknesses.</p>
+
+            <h2 class="govuk-heading-l">Why we need your data</h2>
+            <p>We collect information through Google Analytics to see how you use the service. We do this to help:
+            <ul class="govuk-list govuk-list--bullet">
+                <li>make sure the service is meeting the needs of its users</li>
+                <li>make improvements, for example improving how you navigate the service</li>
+            </ul>
+            </p>
+
+            <p>We also collect data in order to:
+            <ul class="govuk-list govuk-list--bullet">
+                <li>gather feedback to improve our services</li>
+                <li>respond to any feedback you send us, if you’ve asked us to</li>
+                <li>inform you of any issues with the service, such as service downtime</li>
+                <li>monitor use of the site to identify security threats</li>
+            </ul>
+            </p>
+
+            <h2 class="govuk-heading-l">How long we keep your data</h2>
+            <p>We will only retain your personal data for as long as:
+            <ul class="govuk-list govuk-list--bullet">
+                <li>it is needed for the purposes set out in this document</li>
+                <li>the law requires us to</li>
+            </ul>
+
+            <h2 class="govuk-heading-l">Where your data is processed and stored</h2>
+            <p>We design, build and run our service to make sure that your data is as safe as possible at all stages, both while it’s processed and when it’s stored.</p>
+            <p>All personal data is stored in the United Kingdom or European Economic Area (EEA). Data collected by Google Analytics may be transferred outside the UK or EEA for processing.</p>
+
+            <h2 class="govuk-heading-l">How we protect your data and keep it secure</h2>
+            <p>We are committed to doing all that we can to keep your data secure. We have set up systems and processes to prevent unauthorised access or disclosure of your data - for example, we protect your data using varying levels of encryption.</p>
+
+            <h2 class="govuk-heading-l">Disclosing your information</h2>
+            <p>We may pass on your personal information if we have a legal obligation to do so, or if we have to enforce or apply our terms of use and other agreements. This includes exchanging information with other government departments for legal reasons.</p>
+            <p>We will not share your information with any other organisations for marketing, market research or commercial purposes.</p>
+
+            <h2 class="govuk-heading-l">Your rights</h2>
+            <p>You have the right to request:
+            <ul class="govuk-list govuk-list--bullet">
+                <li>information about how your personal data is processed</li>
+                <li>a copy of that personal data</li>
+                <li>that anything inaccurate in your personal data is corrected immediately</li>
+            </ul>
+            </p>
+
+            <p>You can also:
+            <ul class="govuk-list govuk-list--bullet">
+                <li>raise an objection about how your personal data is processed</li>
+                <li>request that your personal data is erased if there is no longer a justification for it</li>
+                <li>ask that the processing of your personal data is restricted in certain circumstances</li>
+            </ul>
+            </p>
+
+            <p>Contact the MoJ data protection officer if you wish to make a request:
+            <address>
+                MoJ Data Protection Officer<br>
+                3rd Floor, Post Point 3.20<br>
+                10 South Colonnades<br>
+                London<br>
+                E14 4PU<br>
+                <a href="mailto:data.compliance@justice.gov.uk">data.compliance@justice.gov.uk</a>
+            </address>
+            </p>
+
+            <p>For more information on how and why your information is processed please see the information provided when you accessed our services or were contacted by us.</p>
+
+
+            <h2 class="govuk-heading-l">Links to other services</h2>
+            <p>The Manage a workforce contains links to other services.</p>
+            <p>This privacy policy only applies to Manage a workforce and does not cover other services and transactions that we link to. These services have their own terms and conditions and privacy policies.</p>
+
+            <h3 class="govuk-heading-m">Following a link to another service</h3>
+            <p>If you go to another service from this one, read the privacy policy on that service to find out what it does with your information.</p>
+
+            <h3 class="govuk-heading-m">Following a link to the Manage a workforce from another service</h3>
+            <p>If you come to Manage a workforce from another service, we may receive information from the other service. We do not use this data. You should read the privacy policy of the service you came from to find out more about this.</p>
+
+            <h2 class="govuk-heading-l">Complaints</h2>
+
+            <p>When we ask you for information, we will keep to the law. If you consider that your information has been handled incorrectly, you can contact the MoJ data protection officer:
+            <address>
+                MoJ Data Protection Officer<br>
+                3rd Floor, Post Point 3.20<br>
+                10 South Colonnades<br>
+                London<br>
+                E14 4PU<br>
+                <a href="mailto:data.compliance@justice.gov.uk">data.compliance@justice.gov.uk</a>
+            </address>
+            </p>
+
+            <p>You can also contact the Information Commissioner for independent advice about data protection.
+            <address>
+                Information Commissioner's Office<br>
+                Wycliffe House<br>
+                Water Lane<br>
+                Wilmslow<br>
+                Cheshire<br>
+                SK9 5AF<br>
+                Tel: 0303 123 1113<br>
+                <a href="http://www.ico.org.uk">www.ico.org.uk</a>
+            </address>
+            </p>
+
+            <h2 class="govuk-heading-l">Changes to this policy</h2>
+
+            <p>We may change this privacy policy. Any changes to this privacy policy will apply to you and your data immediately.</p>
+
+            <p>If these changes affect how your personal data is processed, HMPPS Digital Services will take reasonable steps to let you know.</p>
+
+            <p class="govuk-body-s secondary-text-col">Last updated: 11th November 2021</p>
+        </div>
+    </div>
+
+{% endblock %}

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -78,15 +78,15 @@
         meta: {
             items: [
                 {
-                    href: "/",
+                    href: "/accessibility-statement",
                     text: "Accessibility statement"
                 },
                 {
-                    href: "/",
+                    href: "/cookie-policy",
                     text: "Cookies"
                 },
                 {
-                    href: "/",
+                    href: "/privacy-notice",
                     text: "Privacy"
                 }
             ]


### PR DESCRIPTION
I had already added the footer component when building the layout page, so was already there  but just needed the pages adding for accessibility, privacy and cookies.

The content for accessibility and privacy statements are taken from the prototype, we don't have content for the cookie policy yet so I have left that page 'under construction'.

Following on from Carlo's comment about the pages being accessible to unauthorised users I have now added  this as I think it's a good call as the links will be displayed to unauthorised users in the footer so they should be able to access the pages.