### PR TITLE
:bug: WFP-756: corrected date format

### DIFF
--- a/integration_tests/mockApis/allocations.ts
+++ b/integration_tests/mockApis/allocations.ts
@@ -25,7 +25,7 @@ export default {
             name: 'Sofia Mitchell',
             crn: 'L786545',
             tier: 'C1',
-            sentenceDate: `${dayjs().format('D MMM YYYY')}`,
+            sentenceDate: `${dayjs().format('YYYY-MM-D')}`,
             initialAppointment: null,
             status: 'Previously managed',
             previousConvictionEndDate: '2019-12-13',

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -82,8 +82,8 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   })
 
   njkEnv.addFilter('calculateBusinessDays', (sentenceDate: string) => {
-    const addFiveBusinessDays = moment(sentenceDate, 'D MMM YYYY').businessAdd(5, 'days').format('D MMM YYYY')
-    const apptDue = moment(addFiveBusinessDays, 'D MMM YYYY').businessDiff(moment())
+    const addFiveBusinessDays = moment(sentenceDate, 'YYYY-MM-DD').businessAdd(5, 'days').format('YYYY-MM-DD')
+    const apptDue = moment(addFiveBusinessDays, 'YYYY-MM-DD').businessDiff(moment())
 
     if (apptDue > 5) {
       return 'Overdue'


### PR DESCRIPTION
I've updated the date format - when I was working on the ticket I was using some mock data that had the `sentenceDate` in the format "25 December 2021" as previously we were receiving the date in that format, and I noticed in Mark's demo that this wasn't working correctly. This PR will fix that bug and will now work as expected.