### PR TITLE
:sparkles: wfp-791: added sub headers and text when current and previ…

### DIFF
--- a/integration_tests/integration/probation-record.spec.ts
+++ b/integration_tests/integration/probation-record.spec.ts
@@ -34,4 +34,24 @@ context('Probation record', () => {
     const probationRecordPage = Page.verifyOnPage(ProbationRecordPage)
     probationRecordPage.button().should('contain', 'Allocate')
   })
+
+  it('Current order sub-heading visible on page with body text', () => {
+    cy.task('stubGetUnallocatedCase')
+    cy.signIn()
+    cy.visit('/J678910/case-view')
+    cy.get('a[href*="/probation-record"]').click()
+    const probationRecordPage = Page.verifyOnPage(ProbationRecordPage)
+    probationRecordPage.subHeading().should('contain', 'Current order')
+    probationRecordPage.bodyText().should('contain', 'No current orders.')
+  })
+
+  it('Previous orders sub-heading visible on page with body text', () => {
+    cy.task('stubGetUnallocatedCase')
+    cy.signIn()
+    cy.visit('/J678910/case-view')
+    cy.get('a[href*="/probation-record"]').click()
+    const probationRecordPage = Page.verifyOnPage(ProbationRecordPage)
+    probationRecordPage.subHeading().should('contain', 'Previous orders')
+    probationRecordPage.bodyText().should('contain', 'No previous orders.')
+  })
 })

--- a/integration_tests/pages/probationRecord.ts
+++ b/integration_tests/pages/probationRecord.ts
@@ -10,4 +10,8 @@ export default class ProbationRecordPage extends Page {
   probationRecordHeading = (): PageElement => cy.get('h2.govuk-heading-l')
 
   button = (): PageElement => cy.get('.govuk-button')
+
+  subHeading = (): PageElement => cy.get('h3.govuk-heading-m')
+
+  bodyText = (): PageElement => cy.get('p.govuk-body')
 }

--- a/server/views/pages/probation-record.njk
+++ b/server/views/pages/probation-record.njk
@@ -5,7 +5,22 @@
 
 {% block caseContent %}
 
-            <h2 class="govuk-heading-l">Probation record</h2>
-            <p class="govuk-body">Under construction.</p>
+    <h2 class="govuk-heading-l">Probation record</h2>
+
+    {% if not currentOrder %}
+
+        <h3 class="govuk-heading-m">Current order</h3>
+        <p class="govuk-body">No current orders.</p>
+
+    {% endif %}
+
+    {% if not previousOrders %}
+
+        <h3 class="govuk-heading-m">Previous orders</h3>
+        <p class="govuk-body">No previous orders.</p>
+
+    {% endif %}
+
+
 
 {% endblock %}


### PR DESCRIPTION
…ous orders unavailable

I've added the text to display `No current orders` and `No previous orders` if we don't return current or previous orders. I've included the sub-header in the if statement as when we display the tables the table caption will be the sub-header. 