### PR TITLE
Wfp 787 psr badge

### DIFF
--- a/integration_tests/integration/summary.spec.ts
+++ b/integration_tests/integration/summary.spec.ts
@@ -108,7 +108,7 @@ context('Summary', () => {
       'CPS pack': 'Missing',
       'Pre-convictions': 'Missing',
       'Pre-sentence report': 'No report created',
-      'Last OASys assessment': 'Missing',
+      'Last OASys assessment': 'No assessment created',
     })
   })
 

--- a/integration_tests/integration/summary.spec.ts
+++ b/integration_tests/integration/summary.spec.ts
@@ -107,7 +107,7 @@ context('Summary', () => {
       PNC: 'A/8404713BA',
       'CPS pack': 'Missing',
       'Pre-convictions': 'Missing',
-      'Pre-sentence report': 'Missing',
+      'Pre-sentence report': 'No report created',
       'Last OASys assessment': 'Missing',
     })
   })

--- a/server/views/pages/summary.njk
+++ b/server/views/pages/summary.njk
@@ -146,7 +146,7 @@
                         text: 'Last OASys assessment'
                     },
                         value: {
-                        text: (data.assessment.lastAssessedOn | dateFormat if data.assessment.lastAssessedOn else '<span class="moj-badge moj-badge--red moj-badge--large">Missing</span>' | safe )
+                        text: (data.assessment.lastAssessedOn | dateFormat if data.assessment.lastAssessedOn else '<span class="moj-badge moj-badge--black moj-badge--large">No assessment created</span>' | safe )
                     }
                     }
                 ]

--- a/server/views/pages/summary.njk
+++ b/server/views/pages/summary.njk
@@ -138,7 +138,7 @@
                         html: 'Pre-sentence report' + ('<br><span class="govuk-!-font-size-16 govuk-!-font-weight-regular">' + data.courtReport.description + '</span>' if data.courtReport.description)
                     },
                         value: {
-                        text: (data.courtReport.completedDate | dateFormat if data.courtReport.completedDate else '<span class="moj-badge moj-badge--red moj-badge--large">Missing</span>' | safe )
+                        text: (data.courtReport.completedDate | dateFormat if data.courtReport.completedDate else '<span class="moj-badge moj-badge--black moj-badge--large">No report created</span>' | safe )
                     }
                     },
                     {


### PR DESCRIPTION
Just noticed an image at the bottom of the ticket to display a different badge for PSR's, so this PR is to update to display that instead. I've spoken to Liam about assessments and decided to go with 'No assessment created' so added that also.

<img width="1300" alt="Screenshot 2021-12-07 at 09 52 43" src="https://user-images.githubusercontent.com/51707463/151390010-8d6932da-b783-44da-a5a2-91d9e3069010.png">
