### PR TITLE
changes to styling on docs table

### DIFF
--- a/server/views/pages/documents.njk
+++ b/server/views/pages/documents.njk
@@ -11,7 +11,8 @@
         { text: 'Name',
             attributes: {
                 "aria-sort": "none"
-            }
+            },
+            classes: "govuk-!-width-one-third"
         },
         { text: 'Type',
             attributes: {
@@ -36,7 +37,7 @@
     {%- set tableRow = [
         { html: doubleCell(downloadDocumentLink(crn, convictionId, document.id,document.nameFirstLine), document.nameSecondLine, 'govuk-!-font-size-16 govuk-!-font-weight-regular') + ('<br><strong class="govuk-tag--orange">SENSITIVE</strong>' if document.displaySensitive)},
         { text: document.type },
-        { html: doubleCell(document.eventFirstLine, document.eventSecondLine)},
+        { html: doubleCell(document.eventFirstLine, document.eventSecondLine, 'govuk-!-font-size-16 govuk-!-font-weight-regular')},
         { text:  document.dateCreated, attributes: {
             "data-sort-value": document.dateSortValue
         } }


### PR DESCRIPTION
<img width="1283" alt="Screenshot 2022-11-18 at 12 59 19" src="https://user-images.githubusercontent.com/67792019/202716224-cc7bf136-fd41-4b05-94e8-bdc2192ab577.png">

Changed secondary text size on event column, changes width to one third on name column
