### PR TITLE
WFP-1584: Increase Redis timeout on connect to prevent log errors

### DIFF
--- a/server/data/redisClient.ts
+++ b/server/data/redisClient.ts
@@ -16,6 +16,7 @@ export const createRedisClient = ({ legacyMode }: { legacyMode: boolean }): Redi
     password: config.redis.password,
     legacyMode,
     socket: {
+      connectTimeout: 10000,
       reconnectStrategy: (attempts: number) => {
         // Exponential back off: 20ms, 40ms, 80ms..., capped to retry every 30 seconds
         const nextDelay = Math.min(2 ** attempts * 20, 30000)


### PR DESCRIPTION
The default seems to be 5 seconds, so just upped to 10. I tried it locally without Redis set up and it failed immediately, so this timeout only seems to apply when it can connect but can't complete the request for some reason.

The idea is to try it and see.