### PR TITLE
:sparkles: WFP-1993: Added notification banner

### DIFF
--- a/feature.env
+++ b/feature.env
@@ -5,3 +5,4 @@ API_CLIENT_ID=clientid
 API_CLIENT_SECRET=clientsecret
 SYSTEM_CLIENT_ID=clientid
 SYSTEM_CLIENT_SECRET=clientsecret
+SHOW_NOTIFICATION=true

--- a/helm_deploy/manage-a-workforce-ui/values.yaml
+++ b/helm_deploy/manage-a-workforce-ui/values.yaml
@@ -77,6 +77,7 @@ generic-service:
     NODE_ENV: "production"
     REDIS_TLS_ENABLED: "true"
     TOKEN_VERIFICATION_ENABLED: "true"
+    SHOW_NOTIFICATION: "false"
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/integration_tests/integration/active-cases.spec.ts
+++ b/integration_tests/integration/active-cases.spec.ts
@@ -22,7 +22,12 @@ context('Active Cases', () => {
   })
 
   it('notification banner is not visible when officer has an email', () => {
-    activeCasesPage.notificationBanner().should('not.exist')
+    activeCasesPage
+      .notificationBannerHeading()
+      .should(
+        'not.contain',
+        'You cannot allocate cases to John Doe through the Allocations tool because they do not have an email address associated with their NDelius account.'
+      )
   })
 
   it('notification banner is visible when officer has no email', () => {
@@ -34,6 +39,13 @@ context('Active Cases', () => {
         'contain',
         'You cannot allocate cases to John Doe through the Allocations tool because they do not have an email address associated with their NDelius account.'
       )
+  })
+
+  it('notification banner to inform of service issues is visible when toggled on', () => {
+    activeCasesPage.notificationBanner().should('exist')
+    activeCasesPage
+      .notificationBannerHeading()
+      .should('contain', 'The service is experiencing technical issues, and you may have limited access.')
   })
 
   it('Heading is visible on page', () => {

--- a/integration_tests/integration/choose-practitioner.spec.ts
+++ b/integration_tests/integration/choose-practitioner.spec.ts
@@ -67,7 +67,12 @@ context('Choose Practitioner', () => {
     cy.signIn()
     cy.visit('/pdu/PDU1/J678910/convictions/1/choose-practitioner')
     const regionPage = Page.verifyOnPage(ChoosePractitionerPage)
-    regionPage.notificationBanner().should('not.exist')
+    regionPage
+      .notificationBanner()
+      .should(
+        'not.contain',
+        'If a probation practitioner does not have an email address in NDelius, you cannot allocate cases to them through the Allocations tool.'
+      )
   })
 
   it('Offender details visible on page', () => {

--- a/integration_tests/integration/officer-overview.spec.ts
+++ b/integration_tests/integration/officer-overview.spec.ts
@@ -22,7 +22,12 @@ context('Overview', () => {
   })
 
   it('notification banner is not visible when officer has an email', () => {
-    overviewPage.notificationBanner().should('not.exist')
+    overviewPage
+      .notificationBanner()
+      .should(
+        'not.contain',
+        'You cannot allocate cases to John Doe through the Allocations tool because they do not have an email address associated with their NDelius account.'
+      )
   })
 
   it('notification banner is visible when officer has no email', () => {

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -1,4 +1,4 @@
-export type PageElement = Cypress.Chainable<JQuery>
+export type PageElement = Cypress.Chainable
 
 export default abstract class Page {
   static verifyOnPage<T>(constructor: new () => T): T {
@@ -46,6 +46,8 @@ export default abstract class Page {
   notificationsBadge = (): PageElement => cy.get('.moj-notification-badge')
 
   notificationBanner = (): PageElement => cy.get('.govuk-notification-banner')
+
+  notificationBannerHeading = (): PageElement => cy.get('.govuk-notification-banner__heading')
 
   breadCrumbs = (): PageElement => cy.get('.govuk-breadcrumbs__list-item')
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -23,6 +23,7 @@ import type { Services } from './services'
 import getUnallocatedCasesCount from './middleware/getUnallocatedCasesCount'
 import checkCaseAlreadyAllocated from './middleware/checkCaseAlreadyAllocated'
 import unless from './utils/middlewareUtils'
+import config from './config'
 
 export default function createApp(services: Services): express.Application {
   const app = express()
@@ -30,6 +31,10 @@ export default function createApp(services: Services): express.Application {
   app.set('json spaces', 2)
   app.set('trust proxy', true)
   app.set('port', process.env.PORT || 3000)
+
+  app.locals.notification = {
+    ...config.notification,
+  }
 
   app.use(setUpHealthChecks())
   app.use(setUpWebSecurity())
@@ -45,9 +50,7 @@ export default function createApp(services: Services): express.Application {
   app.use(
     unless('/staff-lookup', getUnallocatedCasesCount(services.userPreferenceService, services.allocationsService))
   )
-
   app.use(routes(services))
-
   app.use((req, res, next) => next(createError(404, 'Not found')))
   app.use('/pdu/:pduCode/:crn/convictions/:convictionNumber/', checkCaseAlreadyAllocated(services.workloadService))
   app.use(errorHandler())

--- a/server/config.ts
+++ b/server/config.ts
@@ -115,4 +115,7 @@ export default {
     return sinceDate
   },
   googleAnalyticsKey: get('GOOGLE_ANALYTICS_KEY', null),
+  notification: {
+    active: get('SHOW_NOTIFICATION', false),
+  },
 }

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -3,6 +3,7 @@
 <head>
 
     {%- from "components/primary-nav/macro.njk" import mawPrimaryNav -%}
+    {%- from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner -%}
 
     {% set mainTitle = "Allocations" %}
 
@@ -96,9 +97,29 @@
 
 
 <div class="govuk-width-container">
-    {% block beforeContent %}{% endblock %}
+    {% block beforeContent %}
+    {% endblock %}
+
     <main class="govuk-main-wrapper" id="main-content" role="main">
-        {% block content %}{% endblock %}
+        {% block notificationBannner %}
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+        {% if notification.active %}
+            {% set html %}
+                    <p class="govuk-notification-banner__heading">The service is experiencing technical issues, and you may have limited access.
+                    </p>
+            {% endset %}
+
+            {{ govukNotificationBanner({
+                html: html
+            }) }}
+        {% endif %}
+            </div>
+        </div>
+        {% endblock %}
+
+        {% block content %}
+        {% endblock %}
     </main>
 </div>
 


### PR DESCRIPTION
- added notification banner component for use when the service is experiencing technical issues and can be toggled on and off using the environment variable `SHOW_NOTIFICATION`, without having to do a code release.
- integration test added, with `SHOW_NOTIFICATION` env var added to the `feature.env` to display the banner in the tests
- Env var added to helm to be used in the environment - set to false. If we want to display the banner we can set the env var to `true`
<img width="847" alt="Screenshot 2023-06-13 at 12 04 20" src="https://github.com/ministryofjustice/manage-a-workforce-ui/assets/51707463/4fac9064-084f-4c4f-809a-19bed9436e8f">
