### PR TITLE
:sparkles: WFP-2291: added staff name to intial appointment date column

### DIFF
--- a/integration_tests/integration/find-unallocated-cases.spec.ts
+++ b/integration_tests/integration/find-unallocated-cases.spec.ts
@@ -141,7 +141,7 @@ context('Find Unallocated cases', () => {
           'Name / CRN': 'Dylan Adam ArmstrongJ678910',
           Tier: 'C1',
           'Sentence date': '1 September 2021',
-          'Initial appointment date': '1 September 2021',
+          'Initial appointment date': '1 September 2021Unallocated officer',
           'Probation status': 'Currently managed(Antonio LoSardo, SPO)',
         },
         {
@@ -155,28 +155,28 @@ context('Find Unallocated cases', () => {
           'Name / CRN': 'John SmithP125643',
           Tier: 'C3',
           'Sentence date': '23 July 2021',
-          'Initial appointment date': '17 August 2021',
+          'Initial appointment date': '1 September 2021Reece John Spears',
           'Probation status': 'New to probation',
         },
         {
           'Name / CRN': 'Kacey RayE124321',
           Tier: 'C2',
           'Sentence date': '1 September 2021',
-          'Initial appointment date': '2 September 2021',
+          'Initial appointment date': '2 September 2021Micheala Smith',
           'Probation status': 'New to probation',
         },
         {
           'Name / CRN': 'Andrew WilliamsP567654',
           Tier: 'C1',
           'Sentence date': '1 September 2021',
-          'Initial appointment date': '3 September 2021',
+          'Initial appointment date': '3 September 2021John Paul Tinker',
           'Probation status': 'Previously managed',
         },
         {
           'Name / CRN': 'Sarah SiddallC567654',
           Tier: 'C2',
           'Sentence date': '1 September 2021',
-          'Initial appointment date': '4 September 2021',
+          'Initial appointment date': '1 September 2021Lando Nickson',
           'Probation status': 'Previously managed',
         },
         {
@@ -190,11 +190,12 @@ context('Find Unallocated cases', () => {
           'Name / CRN': 'Bill TurnerF5635632',
           Tier: 'D1',
           'Sentence date': '1 September 2021',
-          'Initial appointment date': '1 September 2021',
+          'Initial appointment date': '1 September 2021Emma Marie Williams',
           'Probation status': 'Currently managed(Richard Moore)',
         },
       ])
   })
+
   it('clicking clear link removes user preference', () => {
     cy.task('stubPutEmptyUserPreferenceAllocationDemand')
     findUnallocatedCasesPage.clearLink().click()

--- a/integration_tests/mockApis/allocations.ts
+++ b/integration_tests/mockApis/allocations.ts
@@ -10,7 +10,17 @@ export default {
         crn: 'J678910',
         tier: 'C1',
         sentenceDate: '2021-09-01',
-        initialAppointment: '2021-09-01',
+        initialAppointment: {
+          date: '2021-09-01',
+          staff: {
+            name: {
+              forename: 'Unallocated',
+              middlename: null,
+              surname: 'Staff',
+              combinedName: 'Unallocated Staff',
+            },
+          },
+        },
         status: 'Currently managed',
         offenderManager: {
           forenames: 'Antonio',
@@ -40,7 +50,17 @@ export default {
         crn: 'P125643',
         tier: 'C3',
         sentenceDate: '2021-07-23',
-        initialAppointment: '2021-08-17',
+        initialAppointment: {
+          date: '2021-09-01',
+          staff: {
+            name: {
+              forename: 'Reece',
+              middlename: 'John',
+              surname: 'Spears',
+              combinedName: 'Reece John Spears',
+            },
+          },
+        },
         status: 'New to probation',
         convictionNumber: 3,
         caseType: 'COMMUNITY',
@@ -50,7 +70,17 @@ export default {
         crn: 'E124321',
         tier: 'C2',
         sentenceDate: '2021-09-01',
-        initialAppointment: '2021-09-02',
+        initialAppointment: {
+          date: '2021-09-02',
+          staff: {
+            name: {
+              forename: 'Micheala',
+              middlename: null,
+              surname: 'Smith',
+              combinedName: 'Micheala Smith',
+            },
+          },
+        },
         status: 'New to probation',
         convictionNumber: 4,
         caseType: 'COMMUNITY',
@@ -60,7 +90,17 @@ export default {
         crn: 'P567654',
         tier: 'C1',
         sentenceDate: '2021-09-01',
-        initialAppointment: '2021-09-03',
+        initialAppointment: {
+          date: '2021-09-03',
+          staff: {
+            name: {
+              forename: 'John',
+              middlename: 'Paul',
+              surname: 'Tinker',
+              combinedName: 'John Paul Tinker',
+            },
+          },
+        },
         status: 'Previously managed',
         convictionNumber: 5,
         caseType: 'COMMUNITY',
@@ -70,7 +110,17 @@ export default {
         crn: 'C567654',
         tier: 'C2',
         sentenceDate: '2021-09-01',
-        initialAppointment: '2021-09-04',
+        initialAppointment: {
+          date: '2021-09-01',
+          staff: {
+            name: {
+              forename: 'Lando',
+              middlename: null,
+              surname: 'Nickson',
+              combinedName: 'Lando Nickson',
+            },
+          },
+        },
         status: 'Previously managed',
         convictionNumber: 1,
         caseType: 'COMMUNITY',
@@ -90,7 +140,17 @@ export default {
         crn: 'F5635632',
         tier: 'D1',
         sentenceDate: '2021-09-01',
-        initialAppointment: '2021-09-01',
+        initialAppointment: {
+          date: '2021-09-01',
+          staff: {
+            name: {
+              forename: 'Emma',
+              middlename: 'Marie',
+              surname: 'Williams',
+              combinedName: 'Emma Marie Williams',
+            },
+          },
+        },
         status: 'Currently managed',
         offenderManager: {
           forenames: 'Richard',
@@ -119,7 +179,17 @@ export default {
       crn: 'J678910',
       tier: 'C1',
       sentenceDate: '2021-10-17',
-      initialAppointment: '2021-10-22',
+      initialAppointment: {
+        date: '2021-10-22',
+        staff: {
+          name: {
+            forename: 'Reece',
+            middlename: 'John',
+            surname: 'Spears',
+            combinedName: 'Reece John Spears',
+          },
+        },
+      },
       status: 'Currently managed',
       convictionNumber: 1,
       caseType: 'COMMUNITY',

--- a/server/controllers/data/UnallocatedCase.ts
+++ b/server/controllers/data/UnallocatedCase.ts
@@ -70,7 +70,7 @@ export default class UnallocatedCase {
       if (sentenceLength) {
         this.secondaryInitialAppointment += ` (${sentenceLength})`
       }
-    } else if (initialAppointment) {
+    } else if (initialAppointment?.date) {
       this.primaryInitialAppointment = `${dayjs(initialAppointment.date).format(config.dateFormat)}`
       if (initialAppointment.staff?.name?.combinedName !== 'Unallocated Staff') {
         this.secondaryInitialAppointment = initialAppointment.staff?.name?.combinedName

--- a/server/controllers/data/UnallocatedCase.ts
+++ b/server/controllers/data/UnallocatedCase.ts
@@ -3,6 +3,7 @@ import dayjs from 'dayjs'
 import config from '../../config'
 import OffenderManager from '../../models/OffenderManager'
 import tierOrder from './TierOrder'
+import InitialAppointment from '../../models/InitialAppointment'
 
 export default class UnallocatedCase {
   name: string
@@ -19,6 +20,8 @@ export default class UnallocatedCase {
 
   secondaryInitialAppointment: string
 
+  initialAppointment: InitialAppointment
+
   primaryStatus: string
 
   secondaryStatus: string
@@ -30,7 +33,7 @@ export default class UnallocatedCase {
     crn: string,
     tier: string,
     sentenceDate: string,
-    initialAppointment: string,
+    initialAppointment: InitialAppointment,
     primaryStatus: string,
     offenderManager: OffenderManager,
     convictionNumber: number,
@@ -43,6 +46,7 @@ export default class UnallocatedCase {
     this.tierOrder = tierOrder(tier)
     this.sentenceDate = sentenceDate
     this.setInitialAppointment(initialAppointment, caseType, sentenceLength)
+    this.initialAppointment = initialAppointment
     this.primaryStatus = primaryStatus
     if (offenderManager) {
       this.secondaryStatus = `(${offenderManager.forenames} ${offenderManager.surname}${this.getGrade(
@@ -59,7 +63,7 @@ export default class UnallocatedCase {
     return ''
   }
 
-  setInitialAppointment(initialAppointment: string, caseType: string, sentenceLength: string): void {
+  setInitialAppointment(initialAppointment: InitialAppointment, caseType: string, sentenceLength: string): void {
     if (caseType === 'CUSTODY') {
       this.primaryInitialAppointment = 'Not needed'
       this.secondaryInitialAppointment = 'Custody case'
@@ -67,7 +71,12 @@ export default class UnallocatedCase {
         this.secondaryInitialAppointment += ` (${sentenceLength})`
       }
     } else if (initialAppointment) {
-      this.primaryInitialAppointment = `${dayjs(initialAppointment).format(config.dateFormat)}`
+      this.primaryInitialAppointment = `${dayjs(initialAppointment.date).format(config.dateFormat)}`
+      if (initialAppointment.staff?.name?.combinedName !== 'Unallocated Staff') {
+        this.secondaryInitialAppointment = initialAppointment.staff?.name?.combinedName
+      } else {
+        this.secondaryInitialAppointment = 'Unallocated officer'
+      }
     } else {
       this.primaryInitialAppointment = 'Not found'
       this.secondaryInitialAppointment = 'Check with your team'

--- a/server/models/InitialAppointment.ts
+++ b/server/models/InitialAppointment.ts
@@ -1,0 +1,6 @@
+import Staff from './Staff'
+
+export default interface InitialAppointment {
+  date: string
+  staff: Staff
+}

--- a/server/models/Staff.ts
+++ b/server/models/Staff.ts
@@ -1,0 +1,5 @@
+import Name from './Name'
+
+export default interface Staff {
+  name: Name
+}

--- a/server/models/UnallocatedCase.ts
+++ b/server/models/UnallocatedCase.ts
@@ -1,11 +1,12 @@
 import OffenderManager from './OffenderManager'
+import InitialAppointment from './InitialAppointment'
 
 export default interface UnallocatedCase {
   name: string
   crn: string
   tier: string
   sentenceDate: string
-  initialAppointment: string
+  initialAppointment: InitialAppointment
   status: string
   offenderManager: OffenderManager
   sentenceLength: string


### PR DESCRIPTION
![image](https://github.com/ministryofjustice/manage-a-workforce-ui/assets/51707463/8d1c195b-1a75-4b83-9918-5272ba23023d)
![image](https://github.com/ministryofjustice/manage-a-workforce-ui/assets/51707463/b7fad8e6-4c9b-4db3-b464-c5180f1a54d6)

This PR adds the staff name to the initial appointment date column if data available. If staff name comes back as Unallocated Staff it will display `Unallocated officer` as per the content docs.