### PR TITLE
WFP-2270  - Out of area transfers

### DIFF
--- a/assets/sass/hmpps/_team-view.scss
+++ b/assets/sass/hmpps/_team-view.scss
@@ -32,6 +32,11 @@
     border:none;
 }
 
+.govuk-tag {
+    margin-top: 10px;
+    width: 100%;
+}
+
 .card__heading {
     font-size: 48px;
     line-height: 1;

--- a/integration_tests/constants.ts
+++ b/integration_tests/constants.ts
@@ -1,0 +1,3 @@
+const outOfAreasBannerBlurb =
+  'This case is sitting in a different area, and the transfer process must be completed in NDelius before it can be allocated through the service.'
+export default outOfAreasBannerBlurb

--- a/integration_tests/integration/documents.spec.ts
+++ b/integration_tests/integration/documents.spec.ts
@@ -1,9 +1,11 @@
 import Page from '../pages/page'
 import DocumentsPage from '../pages/documents'
+import outOfAreasBannerBlurb from '../constants'
 
 context('Documents', () => {
   beforeEach(() => {
     cy.task('stubSetup')
+    cy.task('stubGetUnallocatedCase')
     cy.task('stubGetCurrentlyManagedCaseOverview')
     cy.task('stubGetDocuments')
     cy.signIn()
@@ -18,6 +20,17 @@ context('Documents', () => {
   it('header visible on page', () => {
     const documentsPage = Page.verifyOnPage(DocumentsPage)
     documentsPage.documentsHeading().should('contain', 'Documents')
+    cy.contains(outOfAreasBannerBlurb).should('not.exist')
+  })
+
+  it('Out of area transfer banner is visible on page and continue button is disabled when case is out of area transfer case', () => {
+    cy.task('stubGetUnallocatedCaseWhereIsOutOfAreaTransfer')
+    cy.reload()
+    const documentsPage = Page.verifyOnPage(DocumentsPage)
+    documentsPage.documentsHeading().should('contain', 'Documents')
+    documentsPage.outOfAreaBanner().should('contain', outOfAreasBannerBlurb)
+    documentsPage.button().should('contain', 'Continue')
+    documentsPage.button().should('have.class', 'govuk-button--disabled')
   })
 
   it('Sub nav visible on page', () => {
@@ -35,9 +48,10 @@ context('Documents', () => {
     documentsPage.highlightedTab().should('contain.text', 'Documents')
   })
 
-  it('Continue button visible on page', () => {
+  it('Continue button enabled and visible on page', () => {
     const documentsPage = Page.verifyOnPage(DocumentsPage)
     documentsPage.button().should('contain', 'Continue')
+    documentsPage.button().should('not.have.class', 'govuk-button--disabled')
   })
 
   it('Instructions text should display', () => {

--- a/integration_tests/integration/find-unallocated-cases.spec.ts
+++ b/integration_tests/integration/find-unallocated-cases.spec.ts
@@ -145,6 +145,13 @@ context('Find Unallocated cases', () => {
           'Probation status': 'Currently managed(Antonio LoSardo, SPO)',
         },
         {
+          'Name / CRN': 'John DoeX678911  Actionrequired',
+          Tier: 'C1',
+          'Sentence date': '1 December 2023',
+          'Initial appointment date':
+            'This case is sitting in a different area, and the transfer process must be completed in NDelius before it can be allocated through the service. You can still review the case details.',
+        },
+        {
           'Name / CRN': 'Sofia MitchellL786545',
           Tier: 'C1',
           'Sentence date': '1 September 2021',

--- a/integration_tests/integration/instructions-text.spec.ts
+++ b/integration_tests/integration/instructions-text.spec.ts
@@ -13,6 +13,7 @@ context('Instructions text', () => {
   })
 
   it('Instructions text should save and display when switching to summary page', () => {
+    cy.task('stubGetUnallocatedCase')
     cy.task('stubGetRisk')
     cy.signIn()
     cy.visit('/pdu/PDU1/J678910/convictions/1/risk')

--- a/integration_tests/integration/probation-record.spec.ts
+++ b/integration_tests/integration/probation-record.spec.ts
@@ -1,9 +1,11 @@
 import Page from '../pages/page'
 import ProbationRecordPage from '../pages/probationRecord'
+import outOfAreasBannerBlurb from '../constants'
 
 context('Probation record', () => {
   beforeEach(() => {
     cy.task('stubSetup')
+    cy.task('stubGetUnallocatedCase')
     cy.signIn()
   })
 
@@ -19,6 +21,18 @@ context('Probation record', () => {
     cy.visit('/pdu/PDU1/J678910/convictions/1/probation-record')
     const probationRecordPage = Page.verifyOnPage(ProbationRecordPage)
     probationRecordPage.probationRecordHeading().should('contain', 'Probation record')
+    cy.contains(outOfAreasBannerBlurb).should('not.exist')
+  })
+
+  it('Out of area transfer banner is visible on page and continue button is disabled when case is out of area transfer case', () => {
+    cy.task('stubGetUnallocatedCaseWhereIsOutOfAreaTransfer')
+    cy.task('stubGetProbationRecord')
+    cy.visit('/pdu/PDU1/J678910/convictions/1/probation-record')
+    const probationRecordPage = Page.verifyOnPage(ProbationRecordPage)
+    probationRecordPage.probationRecordHeading().should('contain', 'Probation record')
+    probationRecordPage.outOfAreaBanner().should('contain', outOfAreasBannerBlurb)
+    probationRecordPage.button().should('contain', 'Continue')
+    probationRecordPage.button().should('have.class', 'govuk-button--disabled')
   })
 
   it('Sub nav visible on page', () => {
@@ -44,7 +58,6 @@ context('Probation record', () => {
     cy.task('stubAllEstateByRegionCode')
     cy.task('stubUserPreferenceAllocationDemand', { pduCode: 'PDU1', lduCode: 'LDU1', teamCode: 'TM1' })
     cy.task('stubGetAllocationsByTeam', { teamCode: 'TM1' })
-    cy.task('stubGetUnallocatedCase')
     cy.task('stubCaseAllocationHistoryCount', 20)
     cy.task('stubGetProbationRecord')
     cy.get('a[href*="/pdu/PDU1/find-unallocated"]').click()
@@ -53,11 +66,12 @@ context('Probation record', () => {
     Page.verifyOnPage(ProbationRecordPage)
   })
 
-  it('Continue button visible on page', () => {
+  it('Continue button enabled and visible on page', () => {
     cy.task('stubGetProbationRecord')
     cy.visit('/pdu/PDU1/J678910/convictions/1/probation-record')
     const probationRecordPage = Page.verifyOnPage(ProbationRecordPage)
     probationRecordPage.button().should('contain', 'Continue')
+    probationRecordPage.button().should('not.have.class', 'govuk-button--disabled')
   })
 
   it('Current sentences sub-heading visible on page with body text', () => {

--- a/integration_tests/integration/risk.spec.ts
+++ b/integration_tests/integration/risk.spec.ts
@@ -1,5 +1,6 @@
 import Page from '../pages/page'
 import RiskPage from '../pages/risk'
+import outOfAreasBannerBlurb from '../constants'
 
 context('Risk', () => {
   beforeEach(() => {
@@ -8,20 +9,35 @@ context('Risk', () => {
   })
 
   it('Caption text visible on page', () => {
+    cy.task('stubGetUnallocatedCase')
     cy.task('stubGetRisk')
     cy.visit('/pdu/PDU1/J678910/convictions/1/risk')
     const riskPage = Page.verifyOnPage(RiskPage)
     riskPage.captionText().should('contain', 'Tier: C1').and('contain', 'CRN: J678910')
   })
 
-  it('Risk header visible on page', () => {
+  it('Risk header visible on page and out of area transfer banner is not visible on page', () => {
+    cy.task('stubGetUnallocatedCase')
     cy.task('stubGetRisk')
     cy.visit('/pdu/PDU1/J678910/convictions/1/risk')
     const riskPage = Page.verifyOnPage(RiskPage)
     riskPage.riskHeading().should('contain', 'Risk')
+    cy.contains(outOfAreasBannerBlurb).should('not.exist')
+  })
+
+  it('Out of area transfer banner is visible on page and continue button is disabled when case is out of area transfer case', () => {
+    cy.task('stubGetUnallocatedCaseWhereIsOutOfAreaTransfer')
+    cy.task('stubGetRisk')
+    cy.visit('/pdu/PDU1/J678910/convictions/1/risk')
+    const riskPage = Page.verifyOnPage(RiskPage)
+    riskPage.riskHeading().should('contain', 'Risk')
+    riskPage.outOfAreaBanner().should('contain', outOfAreasBannerBlurb)
+    riskPage.button().should('contain', 'Continue')
+    riskPage.button().should('have.class', 'govuk-button--disabled')
   })
 
   it('Sub nav visible on page', () => {
+    cy.task('stubGetUnallocatedCase')
     cy.task('stubGetRisk')
     cy.visit('/pdu/PDU1/J678910/convictions/1/risk')
     const riskPage = Page.verifyOnPage(RiskPage)
@@ -34,20 +50,24 @@ context('Risk', () => {
   })
 
   it('Risk tab is highlighted', () => {
+    cy.task('stubGetUnallocatedCase')
     cy.task('stubGetRisk')
     cy.visit('/pdu/PDU1/J678910/convictions/1/risk')
     const riskPage = Page.verifyOnPage(RiskPage)
     riskPage.highlightedTab().should('contain.text', 'Risk')
   })
 
-  it('Continue button visible on page', () => {
+  it('Continue button enabled and visible on page', () => {
+    cy.task('stubGetUnallocatedCase')
     cy.task('stubGetRisk')
     cy.visit('/pdu/PDU1/J678910/convictions/1/risk')
     const riskPage = Page.verifyOnPage(RiskPage)
     riskPage.button().should('contain', 'Continue')
+    riskPage.button().should('not.have.class', 'govuk-button--disabled')
   })
 
   it('Active registrations visible on page', () => {
+    cy.task('stubGetUnallocatedCase')
     cy.task('stubGetRisk')
     cy.visit('/pdu/PDU1/J678910/convictions/1/risk')
     const riskPage = Page.verifyOnPage(RiskPage)
@@ -74,6 +94,7 @@ context('Risk', () => {
   })
 
   it('Inactive registrations visible on page', () => {
+    cy.task('stubGetUnallocatedCase')
     cy.task('stubGetRisk')
     cy.visit('/pdu/PDU1/J678910/convictions/1/risk')
     const riskPage = Page.verifyOnPage(RiskPage)
@@ -97,6 +118,7 @@ context('Risk', () => {
   })
 
   it('Display text when no registrations on the page', () => {
+    cy.task('stubGetUnallocatedCase')
     cy.task('stubGetRiskNoRegistrations')
     cy.visit('/pdu/PDU1/J678910/convictions/1/risk')
     const riskPage = Page.verifyOnPage(RiskPage)
@@ -107,6 +129,7 @@ context('Risk', () => {
   })
 
   it('Displays Assessments when returned', () => {
+    cy.task('stubGetUnallocatedCase')
     cy.task('stubGetRisk')
     cy.visit('/pdu/PDU1/J678910/convictions/1/risk')
     const riskPage = Page.verifyOnPage(RiskPage)
@@ -137,6 +160,7 @@ context('Risk', () => {
   })
 
   it('Displays Not Found Assessment', () => {
+    cy.task('stubGetUnallocatedCase')
     cy.task('stubGetNotFoundRisk')
     cy.visit('/pdu/PDU1/J678910/convictions/1/risk')
     const riskPage = Page.verifyOnPage(RiskPage)
@@ -166,6 +190,7 @@ context('Risk', () => {
   })
 
   it('Displays Unavailable Assessment', () => {
+    cy.task('stubGetUnallocatedCase')
     cy.task('stubGetUnavailableRisk')
     cy.visit('/pdu/PDU1/J678910/convictions/1/risk')
     const riskPage = Page.verifyOnPage(RiskPage)

--- a/integration_tests/integration/summary.spec.ts
+++ b/integration_tests/integration/summary.spec.ts
@@ -1,5 +1,6 @@
 import Page from '../pages/page'
 import SummaryPage from '../pages/summary'
+import outOfAreasBannerBlurb from '../constants'
 
 context('Summary', () => {
   beforeEach(() => {
@@ -14,9 +15,20 @@ context('Summary', () => {
     summaryPage.captionText().should('contain', 'Tier: C1').and('contain', 'CRN: J678910')
   })
 
-  it('Summary header visible on page', () => {
+  it('Summary header visible on page and out of area transfer banner is not visible on page', () => {
     const summaryPage = Page.verifyOnPage(SummaryPage)
     summaryPage.summaryHeading().should('contain', 'Summary')
+    cy.contains(outOfAreasBannerBlurb).should('not.exist')
+  })
+
+  it('Out of area transfer banner is visible on page and continue button is disabled when case is out of area transfer case', () => {
+    cy.task('stubGetUnallocatedCaseWhereIsOutOfAreaTransfer')
+    cy.reload()
+    const summaryPage = Page.verifyOnPage(SummaryPage)
+    summaryPage.summaryHeading().should('contain', 'Summary')
+    summaryPage.outOfAreaBanner().should('contain', outOfAreasBannerBlurb)
+    summaryPage.button().should('contain', 'Continue')
+    summaryPage.button().should('have.class', 'govuk-button--disabled')
   })
 
   it('Sub nav visible on page', () => {
@@ -34,9 +46,10 @@ context('Summary', () => {
     summaryPage.highlightedTab().should('contain.text', 'Summary')
   })
 
-  it('Continue button visible on page', () => {
+  it('Continue button enabled and visible on page', () => {
     const summaryPage = Page.verifyOnPage(SummaryPage)
     summaryPage.button().should('contain', 'Continue')
+    summaryPage.button().should('not.have.class', 'govuk-button--disabled')
   })
 
   it('Personal details visible on page', () => {

--- a/integration_tests/mockApis/allocations.ts
+++ b/integration_tests/mockApis/allocations.ts
@@ -29,6 +29,33 @@ export default {
         },
         convictionNumber: 1,
         caseType: 'COMMUNITY',
+        outOfAreaTransfer: false,
+      },
+      {
+        name: 'John Doe',
+        crn: 'X678911',
+        tier: 'C1',
+        sentenceDate: '2023-12-01',
+        initialAppointment: {
+          date: '2023-12-20',
+          staff: {
+            name: {
+              forename: 'Unallocated',
+              middlename: null,
+              surname: 'Staff',
+              combinedName: 'Unallocated Staff',
+            },
+          },
+        },
+        status: 'Currently managed',
+        offenderManager: {
+          forenames: 'Jane',
+          surname: 'Doe',
+          grade: 'SPO',
+        },
+        convictionNumber: 1,
+        caseType: 'COMMUNITY',
+        outOfAreaTransfer: true,
       },
       {
         name: 'Sofia Mitchell',
@@ -44,6 +71,7 @@ export default {
         convictionNumber: 2,
         caseType: 'CUSTODY',
         sentenceLength: '32 Years',
+        outOfAreaTransfer: false,
       },
       {
         name: 'John Smith',
@@ -64,6 +92,7 @@ export default {
         status: 'New to probation',
         convictionNumber: 3,
         caseType: 'COMMUNITY',
+        outOfAreaTransfer: false,
       },
       {
         name: 'Kacey Ray',
@@ -84,6 +113,7 @@ export default {
         status: 'New to probation',
         convictionNumber: 4,
         caseType: 'COMMUNITY',
+        outOfAreaTransfer: false,
       },
       {
         name: 'Andrew Williams',
@@ -104,6 +134,7 @@ export default {
         status: 'Previously managed',
         convictionNumber: 5,
         caseType: 'COMMUNITY',
+        outOfAreaTransfer: false,
       },
       {
         name: 'Sarah Siddall',
@@ -124,6 +155,7 @@ export default {
         status: 'Previously managed',
         convictionNumber: 1,
         caseType: 'COMMUNITY',
+        outOfAreaTransfer: false,
       },
       {
         name: 'Mick Jones',
@@ -134,6 +166,7 @@ export default {
         status: 'Previously managed',
         convictionNumber: 6,
         caseType: 'COMMUNITY',
+        outOfAreaTransfer: false,
       },
       {
         name: 'Bill Turner',
@@ -158,6 +191,7 @@ export default {
         },
         convictionNumber: 7,
         caseType: 'COMMUNITY',
+        outOfAreaTransfer: false,
       },
     ],
   }): SuperAgentRequest => {
@@ -278,6 +312,83 @@ export default {
           rsrLevel: 'MEDIUM',
           ogrsScore: 85,
           activeRiskRegistration: 'ALT Under MAPPA Arrangements, Suicide/self-harm',
+        },
+      },
+    })
+  },
+  stubGetUnallocatedCaseWhereIsOutOfAreaTransfer: (): SuperAgentRequest => {
+    return stubForAllocation({
+      request: {
+        method: 'GET',
+        urlPattern: `/cases/unallocated/J678910/convictions/1`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: {
+          name: 'Dylan Adam Armstrong',
+          crn: 'J678910',
+          tier: 'C1',
+          sentenceDate: '2021-09-01',
+          gender: 'Male',
+          dateOfBirth: '1984-09-27',
+          age: 37,
+          offences: [
+            {
+              mainOffence: true,
+              mainCategory: 'Common assault and battery',
+              subCategory: 'Contrary to section 39 of the Criminal Justice Act 1988.',
+            },
+          ],
+          expectedSentenceEndDate: '2021-09-28',
+          sentenceLength: '6 Months',
+          sentenceDescription: 'SA2020 Suspended Sentence Order',
+          requirements: [
+            {
+              mainCategory: 'Unpaid Work',
+              subCategory: 'Regular',
+              length: '100 Hours',
+            },
+          ],
+          pncNumber: 'D/9874483AB',
+          courtReport: {
+            description: 'Pre-Sentence Report - Fast',
+            completedDate: '2022-01-27T10:54:32.868Z',
+            documentId: '00000000-0000-0000-0000-000000000000',
+            name: 'courtFile.pdf',
+          },
+          cpsPack: {
+            completedDate: '2022-02-27T10:54:32.868Z',
+            documentId: '11111111-1111-1111-1111-111111111111',
+            name: 'cpsPackFile.pdf',
+          },
+          preConvictionDocument: {
+            completedDate: '2022-03-27T10:54:32.868Z',
+            documentId: '22222222-2222-2222-2222-222222222222',
+            name: 'preConsFile.pdf',
+          },
+          assessment: {
+            lastAssessedOn: '2022-01-27T10:54:32.869Z',
+            type: 'LAYER_3',
+          },
+          convictionNumber: 1,
+          address: {
+            addressNumber: '5A',
+            buildingName: 'The Building',
+            streetName: 'The Street',
+            town: 'Reading',
+            county: 'Berkshire',
+            postcode: 'RG22 3EF',
+            noFixedAbode: false,
+            typeVerified: true,
+            typeDescription: 'Rental accommodation',
+            startDate: '2022-08-25',
+          },
+          roshLevel: 'VERY_HIGH',
+          rsrLevel: 'MEDIUM',
+          ogrsScore: 85,
+          activeRiskRegistration: 'ALT Under MAPPA Arrangements, Suicide/self-harm',
+          outOfAreaTransfer: true,
         },
       },
     })

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -39,6 +39,8 @@ export default abstract class Page {
 
   headingText = (): PageElement => cy.get('.govuk-heading-xl')
 
+  outOfAreaBanner = (): PageElement => cy.get('.govuk-notification-banner__heading')
+
   primaryNav = (): PageElement => cy.get('ul.moj-primary-navigation__list').children()
 
   navLink = (linkId: string): PageElement => cy.get(`#${linkId}`).invoke('attr', 'href')

--- a/server/controllers/data/UnallocatedCase.ts
+++ b/server/controllers/data/UnallocatedCase.ts
@@ -28,6 +28,8 @@ export default class UnallocatedCase {
 
   convictionNumber: number
 
+  outOfAreaTransfer: boolean
+
   constructor(
     name: string,
     crn: string,
@@ -38,7 +40,8 @@ export default class UnallocatedCase {
     offenderManager: OffenderManager,
     convictionNumber: number,
     caseType: string,
-    sentenceLength: string
+    sentenceLength: string,
+    outOfAreaTransfer: boolean
   ) {
     this.name = name
     this.crn = crn
@@ -54,6 +57,7 @@ export default class UnallocatedCase {
       )})`
     }
     this.convictionNumber = convictionNumber
+    this.outOfAreaTransfer = outOfAreaTransfer
   }
 
   getGrade(grade: string): string {

--- a/server/controllers/findUnallocatedCasesController.ts
+++ b/server/controllers/findUnallocatedCasesController.ts
@@ -57,7 +57,8 @@ export default class FindUnallocatedCasesController {
           value.offenderManager,
           value.convictionNumber,
           value.caseType,
-          value.sentenceLength
+          value.sentenceLength,
+          value.outOfAreaTransfer
         )
     )
 

--- a/server/models/Allocation.ts
+++ b/server/models/Allocation.ts
@@ -25,4 +25,5 @@ export default interface Allocation {
   address: Address
   sentenceLength: string
   convictionNumber: number
+  outOfAreaTransfer: boolean
 }

--- a/server/models/UnallocatedCase.ts
+++ b/server/models/UnallocatedCase.ts
@@ -12,4 +12,5 @@ export default interface UnallocatedCase {
   sentenceLength: string
   convictionNumber: number
   caseType: string
+  outOfAreaTransfer: boolean
 }

--- a/server/views/components/tripleCell/macro.njk
+++ b/server/views/components/tripleCell/macro.njk
@@ -1,0 +1,10 @@
+{% macro tripleCell(first, second, secondStyle, third) -%}
+{{ first | safe}}
+{% if second -%}
+  <br><span class="{{ secondStyle }}">{{ second | safe }}
+{%- endif %}
+{% if third -%}
+  <br>
+  {{ third | safe}}
+{%- endif %}
+{%- endmacro %}

--- a/server/views/pages/find-unallocated-cases.njk
+++ b/server/views/pages/find-unallocated-cases.njk
@@ -4,6 +4,7 @@
 {%- from "govuk/components/button/macro.njk" import govukButton -%}
 {%- from "govuk/components/table/macro.njk" import govukTable -%}
 {%- from "../components/doubleCell/macro.njk" import doubleCell -%}
+{%- from "../components/tripleCell/macro.njk" import tripleCell -%}
 
 {% set tableData = {
     attributes: {
@@ -48,7 +49,12 @@
 {% for item in unallocatedCases %}
     {% if item.outOfAreaTransfer == true %}
         {%- set tableRow = [
-            { text: doubleCell('<a href="/pdu/' + pduCode +'/' + item.crn + '/convictions/' + item.convictionNumber +'/case-view" " class="govuk-link--no-visited-state" aria-label="Review case" data-qa-link="' + item.crn + '-' + item.convictionNumber +'"">' +  item.name + '</a>', item.crn, 'govuk-body-s' )},
+            { text: tripleCell(
+                '<a href="/pdu/' + pduCode +'/' + item.crn + '/convictions/' + item.convictionNumber +'/case-view" " class="govuk-link--no-visited-state" aria-label="Review case" data-qa-link="' + item.crn + '-' + item.convictionNumber +'"">' +  item.name + '</a>',
+                item.crn,
+                'govuk-body-s',
+                '<span><strong class="govuk-tag">Action<br>required</strong></span>'
+            )},
             { text: item.tier, attributes: { "data-sort-value": item.tierOrder } },
             { text: (item.sentenceDate | dateFormat), attributes: {
                 "data-sort-value": item.sentenceDate

--- a/server/views/pages/find-unallocated-cases.njk
+++ b/server/views/pages/find-unallocated-cases.njk
@@ -46,17 +46,31 @@
 } %}
 
 {% for item in unallocatedCases %}
-    {%- set tableRow = [
-        { text: doubleCell('<a href="/pdu/' + pduCode +'/' + item.crn + '/convictions/' + item.convictionNumber +'/case-view" " class="govuk-link--no-visited-state" aria-label="Review case" data-qa-link="' + item.crn + '-' + item.convictionNumber +'"">' +  item.name + '</a>', item.crn, 'govuk-body-s' )},
-        { text: item.tier, attributes: { "data-sort-value": item.tierOrder } },
-        { text: (item.sentenceDate | dateFormat), attributes: {
-            "data-sort-value": item.sentenceDate
-        } },
-        { text: doubleCell(item.primaryInitialAppointment,item.secondaryInitialAppointment, 'maw-secondary' )},
-        { text: doubleCell(item.primaryStatus, item.secondaryStatus, 'govuk-body-s')}
-    ] -%}
-    {{ tableData.rows.push(tableRow) }}
-
+    {% if item.outOfAreaTransfer == true %}
+        {%- set tableRow = [
+            { text: doubleCell('<a href="/pdu/' + pduCode +'/' + item.crn + '/convictions/' + item.convictionNumber +'/case-view" " class="govuk-link--no-visited-state" aria-label="Review case" data-qa-link="' + item.crn + '-' + item.convictionNumber +'"">' +  item.name + '</a>', item.crn, 'govuk-body-s' )},
+            { text: item.tier, attributes: { "data-sort-value": item.tierOrder } },
+            { text: (item.sentenceDate | dateFormat), attributes: {
+                "data-sort-value": item.sentenceDate
+            } },
+            {
+                colspan: "2",
+                text: 'This case is sitting in a different area, and the transfer process must be completed in NDelius before it can be allocated through the service. You can still review the case details.', attributes: { "data-sort-value": item.tierOrder }
+            }
+        ] -%}
+        {{ tableData.rows.push(tableRow) }}
+    {% else %}
+        {%- set tableRow = [
+            { text: doubleCell('<a href="/pdu/' + pduCode +'/' + item.crn + '/convictions/' + item.convictionNumber +'/case-view" " class="govuk-link--no-visited-state" aria-label="Review case" data-qa-link="' + item.crn + '-' + item.convictionNumber +'"">' +  item.name + '</a>', item.crn, 'govuk-body-s' )},
+            { text: item.tier, attributes: { "data-sort-value": item.tierOrder } },
+            { text: (item.sentenceDate | dateFormat), attributes: {
+                "data-sort-value": item.sentenceDate
+            } },
+            { text: doubleCell(item.primaryInitialAppointment,item.secondaryInitialAppointment, 'maw-secondary' )},
+            { text: doubleCell(item.primaryStatus, item.secondaryStatus, 'govuk-body-s')}
+        ] -%}
+        {{ tableData.rows.push(tableRow) }}
+    {% endif %}
 {% endfor %}
 
 {% block allocationContent %}

--- a/server/views/partials/case-view.njk
+++ b/server/views/partials/case-view.njk
@@ -21,6 +21,19 @@
 {% endblock %}
 
 {% block content %}
+    {% if outOfAreaTransfer == true %}
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+                {{ govukNotificationBanner({
+                    html: '
+                   <p class="govuk-notification-banner__heading">
+                     This case is sitting in a different area, and the transfer process must be completed in NDelius before it can be allocated through the service. You can still review the case details.
+                   </p>
+                '
+                }) }}
+            </div>
+        </div>
+    {% endif %}
 
     {{ pop({name: name, crn: crn, tier: tier, convictionNumber: convictionNumber, pduCode: pduCode}) }}
 
@@ -64,7 +77,8 @@
         text: "Continue",
         href: "/pdu/" + pduCode + "/" + crn + "/convictions/" + convictionNumber + "/choose-practitioner",
         classes: "allocate",
-        id: convictionNumber
+        id: convictionNumber,
+        disabled: outOfAreaTransfer
     }) }}
 
     {% block feedbackPrompt %}{% endblock %}


### PR DESCRIPTION
PR for `Out of area transfers` which:
1. shows `Action required` tag and blurb for appropriate cases on the `Unallocated Cases` screen

![01_ooa](https://github.com/ministryofjustice/manage-a-workforce-ui/assets/148795810/8237d91b-aacd-4785-8748-439ada9132b5)

2. shows `Out of areas banner` and disables `Continue` button on the `Case View` page (for all tabs) when case is an out of area transfer

<img width="1600" alt="Screenshot 2024-01-03 at 17 52 57 (2)" src="https://github.com/ministryofjustice/manage-a-workforce-ui/assets/148795810/39e8dc91-442b-4f78-be10-c037afded4e7">
