### PR TITLE
:sparkles: WFP-2300: updated technical updates link

### DIFF
--- a/integration_tests/integration/technical-updates.spec.ts
+++ b/integration_tests/integration/technical-updates.spec.ts
@@ -24,7 +24,7 @@ context('Technical Updates', () => {
 
   it('send us feedback visible on page', () => {
     const technicalUpdatesPage = Page.verifyOnPage(TechnicalUpdatesPage)
-    technicalUpdatesPage.sendFeedback().should('have.text', 'Send us feedback by email.')
+    technicalUpdatesPage.sendFeedback().should('have.text', 'Send us feedback on the Allocations tool')
   })
 
   it('technical updates banner not visible on page', () => {

--- a/server/views/pages/technical-updates.njk
+++ b/server/views/pages/technical-updates.njk
@@ -60,7 +60,7 @@
 </div>
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <p data-qa-link="send-feedback">Send us feedback <a class="govuk-link--no-visited-state" href="mailto:manageaworkforce@justice.gov.uk">by email</a>.</p>
+        <p data-qa-link="send-feedback"><a class="govuk-link--no-visited-state" href="https://forms.office.com/Pages/ResponsePage.aspx?id=KEeHxuZx_kGp4S6MNndq2JfL5_1h2G9Gi17tzGJyJ5hUMjI3UDgwVzgwS1JLV0hXNDFOTjc4Q1FCQi4u">Send us feedback on the Allocations tool</a></p>
 
         {{ govukAccordion({
             id: "accordion-default",


### PR DESCRIPTION
This PR updates the text in the link on the technical updates page and rather than sending an email to the team links to the feedback form.
<img width="702" alt="Screenshot 2024-01-09 at 09 42 43" src="https://github.com/ministryofjustice/manage-a-workforce-ui/assets/51707463/6142d218-f568-4f1e-8fea-21dfeb65eb3e">
