### PR TITLE
Feature/wfp 2274  display handover date and make sortable

### DIFF
--- a/assets/js/mojSortableTable.js
+++ b/assets/js/mojSortableTable.js
@@ -329,10 +329,10 @@ $(() => {
     const sortDataTypeIsDate = isSortDataTypeADate(clickedColumn.columnDataType)
     var newRows = rows.sort(
       $.proxy(function (rowA, rowB) {
-        var tdA = $(rowA).find('td,th').eq(columnIndex)
-        var tdB = $(rowB).find('td,th').eq(columnIndex)
-        var valueA = this.getCellValue(tdA)
-        var valueB = this.getCellValue(tdB)
+        const tdA = $(rowA).find('td,th').eq(columnIndex)
+        const tdB = $(rowB).find('td,th').eq(columnIndex)
+        const valueA = this.getCellValue(tdA)
+        const valueB = this.getCellValue(tdB)
         if (sortDirection === 'ascending') {
           if (sortDataTypeIsDate) {
             return sortDateAsc(valueA, valueB, clickedColumn.columnDataType)

--- a/assets/js/mojSortableTable.js
+++ b/assets/js/mojSortableTable.js
@@ -1,3 +1,39 @@
+const fetchSortOrderDTO = tablePersistentId => {
+  const key = this.sortOrderLocalStorageKey(tablePersistentId)
+  const serialized = window.localStorage.getItem(key)
+  if (serialized === null) {
+    return null
+  }
+  const deserialized = JSON.parse(serialized)
+  if (
+    !(
+      typeof deserialized === 'object' &&
+      deserialized !== null &&
+      'columnPersistentId' in deserialized &&
+      'order' in deserialized
+    )
+  ) {
+    return null
+  }
+  // I’m not sure why a cast is necessary; I’d have thought the compiler
+  // would allow us to assign directly to a variable of this type given
+  // the above check, but no…
+  const keyed = deserialized
+  if (!(typeof keyed.columnPersistentId === 'string')) {
+    return null
+  }
+  const withTypedValues = {
+    columnPersistentId: keyed.columnPersistentId,
+    order: this.createARIASort(keyed.order),
+    datePatternForSort: keyed.datePatternForSort,
+  }
+  if (withTypedValues.order === null) {
+    return null
+  }
+  // Ditto re “not sure why a cast is necessary”
+  return withTypedValues
+}
+
 class PersistentSortOrder {
   static activate(table) {
     const tablePersistentId = table.dataset.persistentId
@@ -6,7 +42,7 @@ class PersistentSortOrder {
       return
     }
     this.observeAttributeChanges(tablePersistentId)
-    const sortOrder = this.fetchSortOrderDTO(tablePersistentId)
+    const sortOrder = fetchSortOrderDTO(tablePersistentId)
     if (sortOrder !== null) {
       this.forceSortOrder(table, sortOrder)
     }
@@ -45,6 +81,8 @@ class PersistentSortOrder {
           console.warn('Unrecognised aria-sort attribute')
           return
         }
+        const columnNumber = header.getAttribute('col-number')
+        const datePatternForSort = header.getAttribute('date-pattern-for-sort')
         const columnPersistentId = header.dataset.persistentId
         if (columnPersistentId === undefined) {
           console.warn('Column has no data-persistent-id attribute; cannot persist chosen order.')
@@ -52,53 +90,27 @@ class PersistentSortOrder {
         }
         // IE11 doesn't support `.includes`, so we're using `indexOf` here.
         if (['descending', 'ascending'].indexOf(newAriaSort) > -1) {
-          this.persistSortOrder(tablePersistentId, columnPersistentId, newAriaSort)
+          this.persistSortOrder(tablePersistentId, columnPersistentId, newAriaSort, datePatternForSort, columnNumber)
+          this.persistCurrentTablePersistentId(tablePersistentId)
         }
       }
     })
   }
-  static localStorageKey(tablePersistentId) {
+  static sortOrderLocalStorageKey(tablePersistentId) {
     return `sortOrder:${tablePersistentId}`
   }
-  static persistSortOrder(tablePersistentId, columnPersistentId, order) {
-    const key = this.localStorageKey(tablePersistentId)
-    const object = { columnPersistentId, order }
+
+  static persistSortOrder(tablePersistentId, columnPersistentId, order, datePatternForSort, columnNumber) {
+    const key = this.sortOrderLocalStorageKey(tablePersistentId)
+    const object = { columnPersistentId, order, datePatternForSort, columnNumber }
     window.localStorage.setItem(key, JSON.stringify(object))
   }
-  static fetchSortOrderDTO(tablePersistentId) {
-    const key = this.localStorageKey(tablePersistentId)
-    const serialized = window.localStorage.getItem(key)
-    if (serialized === null) {
-      return null
-    }
-    const deserialized = JSON.parse(serialized)
-    if (
-      !(
-        typeof deserialized === 'object' &&
-        deserialized !== null &&
-        'columnPersistentId' in deserialized &&
-        'order' in deserialized
-      )
-    ) {
-      return null
-    }
-    // I’m not sure why a cast is necessary; I’d have thought the compiler
-    // would allow us to assign directly to a variable of this type given
-    // the above check, but no…
-    const keyed = deserialized
-    if (!(typeof keyed.columnPersistentId === 'string')) {
-      return null
-    }
-    const withTypedValues = {
-      columnPersistentId: keyed.columnPersistentId,
-      order: this.createARIASort(keyed.order),
-    }
-    if (withTypedValues.order === null) {
-      return null
-    }
-    // Ditto re “not sure why a cast is necessary”
-    return withTypedValues
+
+  static persistCurrentTablePersistentId(tablePersistentId) {
+    const object = { tablePersistentId }
+    window.localStorage.setItem('currentTablePersistentId', JSON.stringify(object))
   }
+
   static forceSortOrder(table, sortOrder) {
     const headers = table.querySelectorAll('thead th')
     let header
@@ -165,15 +177,130 @@ $(() => {
     return
   }
 
-  class SortableTable extends MOJFrontend.SortableTable {
-    constructor(tableElement) {
-      super({ table: tableElement })
+  function SortableTable(tableElement) {
+    // Calls the SortableTable constructor with `this` as its context
+    MOJFrontend.SortableTable.call(this, tableElement)
+  }
+  SortableTable.prototype = Object.create(MOJFrontend.SortableTable.prototype)
+
+  function sortStringAsc(valueA, valueB) {
+    if (valueA < valueB) {
+      return -1
     }
-    // overrides MOJFrontend.SortableTable.sort function
-    sort(rows, columnNumber, sortDirection) {
-      return super.sort(rows, columnNumber, sortDirection)
+    if (valueA > valueB) {
+      return 1
+    }
+    return 0
+  }
+
+  function sortStringDesc(valueA, valueB) {
+    if (valueB < valueA) {
+      return -1
+    }
+    if (valueB > valueA) {
+      return 1
+    }
+    return 0
+  }
+
+  function sortDateAsc(date1String, date2String, datePatternForSort) {
+    const { date1, date2 } = extractAndConvertDates(date1String, date2String, datePatternForSort)
+    if (date1 < date2) {
+      return -1
+    } else if (date1 > date2) {
+      return 1
+    }
+    return 0
+  }
+
+  function sortDateDesc(date1String, date2String, datePatternForSort) {
+    const { date1, date2 } = extractAndConvertDates(date1String, date2String, datePatternForSort)
+    if (date2 < date1) {
+      return -1
+    }
+    if (date2 > date1) {
+      return 1
+    }
+    return 0
+  }
+
+  function extractAndConvertDates(date1String, date2String, datePatternForSort) {
+    const dare1Extracted = extractDateFromValue(date1String, datePatternForSort)
+    const dare2Extracted = extractDateFromValue(date2String, datePatternForSort)
+    let date1
+    if (dare1Extracted) {
+      date1 = new Date(dare1Extracted)
+    } else {
+      date1 = new Date('1970-01-01')
+    }
+    let date2
+    if (dare2Extracted) {
+      date2 = new Date(dare2Extracted)
+    } else {
+      date2 = new Date('1970-01-01')
+    }
+    return {
+      date1,
+      date2,
     }
   }
+
+  function extractDateFromValue(value, datePatternForSort) {
+    //todo: get the date regex-pattern working for YYYY-MM-DD or consider attempting to create a Date() object from the "value" in a try and catch
+    const arr = value.match('enter regex-pattern here') || [''] //could also use null for empty value
+    return arr[0]
+  }
+
+  function fetchCurrentTablePersistentIdDTO() {
+    const key = 'currentTablePersistentId'
+    const serialized = window.localStorage.getItem(key)
+    if (serialized === null) {
+      return null
+    }
+    const deserialized = JSON.parse(serialized)
+    if (!(typeof deserialized === 'object' && deserialized !== null && 'tablePersistentId' in deserialized)) {
+      return null
+    }
+    // I’m not sure why a cast is necessary; I’d have thought the compiler
+    // would allow us to assign directly to a variable of this type given
+    // the above check, but no…
+    const keyed = deserialized
+    if (!(typeof keyed.tablePersistentId === 'string')) {
+      return null
+    }
+    const withTypedValues = {
+      columnPersistentId: keyed.tablePersistentId,
+    }
+    return withTypedValues
+  }
+
+  MOJFrontend.SortableTable.prototype.sort = function (rows, columnNumber, sortDirection) {
+    const currentTablePersistentIdDTO = fetchCurrentTablePersistentIdDTO()
+    const sortOrder = fetchSortOrderDTO(currentTablePersistentIdDTO)
+    var newRows = rows.sort(
+      $.proxy(function (rowA, rowB) {
+        var tdA = $(rowA).find('td,th').eq(columnNumber)
+        var tdB = $(rowB).find('td,th').eq(columnNumber)
+        var valueA = this.getCellValue(tdA)
+        var valueB = this.getCellValue(tdB)
+        if (sortDirection === 'ascending') {
+          if (sortOrder.datePatternForSort) {
+            return sortDateAsc(valueA, valueB, sortOrder.datePatternForSort)
+          } else {
+            return sortStringAsc(valueA, valueB)
+          }
+        } else {
+          if (sortOrder.datePatternForSort) {
+            return sortDateDesc(valueA, valueB, sortOrder.datePatternForSort)
+          } else {
+            return sortStringDesc(valueA, valueB)
+          }
+        }
+      }, this)
+    )
+    return newRows
+  }
+  SortableTable.prototype.constructor = SortableTable
 
   Array.from(tables).forEach(function (table) {
     new SortableTable(table)

--- a/assets/js/mojSortableTable.js
+++ b/assets/js/mojSortableTable.js
@@ -245,8 +245,8 @@ $(() => {
     return 0
   }
 
-  function sortDateAsc(date1String, date2String, dateDataType) {
-    const { date1, date2 } = extractAndConvertDates(date1String, date2String, dateDataType)
+  function sortDateAsc(date1String, date2String) {
+    const { date1, date2 } = convertDates(date1String, date2String)
     if (date1 < date2) {
       return -1
     } else if (date1 > date2) {
@@ -255,8 +255,8 @@ $(() => {
     return 0
   }
 
-  function sortDateDesc(date1String, date2String, dateDataType) {
-    const { date1, date2 } = extractAndConvertDates(date1String, date2String, dateDataType)
+  function sortDateDesc(date1String, date2String) {
+    const { date1, date2 } = convertDates(date1String, date2String)
     if (date2 < date1) {
       return -1
     }
@@ -270,37 +270,23 @@ $(() => {
     return value !== undefined && value !== '' && value !== 'N/A'
   }
 
-  function extractAndConvertDates(date1String, date2String, dateDataType) {
+  function convertDates(date1String, date2String) {
     return {
-      date1: extractAndConvertDate(date1String, dateDataType),
-      date2: extractAndConvertDate(date2String, dateDataType),
+      date1: convertDate(date1String),
+      date2: convertDate(date2String),
     }
   }
 
-  function extractAndConvertDate(dateString, dateDataType) {
+  function convertDate(dateString) {
     const farInTheFutureDate = Date.parse('3000-01-01')
     if (valueIsSet(dateString)) {
-      const extractedDateString = extractDateFromValue(dateString, dateDataType)
-      if (extractedDateString) {
-        let convertedDate = Date.parse(extractedDateString)
-        if (isNaN(convertedDate)) {
-          convertedDate = farInTheFutureDate
-        }
-        return convertedDate
+      let convertedDate = Date.parse(dateString)
+      if (isNaN(convertedDate)) {
+        convertedDate = farInTheFutureDate
       }
+      return convertedDate
     }
     return farInTheFutureDate
-  }
-
-  function extractDateFromValue(value, dateDataType) {
-    if (dateDataType === 'DATE_ON_FIRST_LINE') {
-      const lines = value.split('\n')
-      if (lines.length > 1) {
-        return lines[0]
-      }
-      return undefined
-    }
-    return value
   }
 
   function isSortDataTypeADate(dataType) {
@@ -335,13 +321,13 @@ $(() => {
         const valueB = this.getCellValue(tdB)
         if (sortDirection === 'ascending') {
           if (sortDataTypeIsDate) {
-            return sortDateAsc(valueA, valueB, clickedColumn.columnDataType)
+            return sortDateAsc(valueA, valueB)
           } else {
             return sortStringAsc(valueA, valueB)
           }
         } else {
           if (sortDataTypeIsDate) {
-            return sortDateDesc(valueA, valueB, clickedColumn.columnDataType)
+            return sortDateDesc(valueA, valueB)
           } else {
             return sortStringDesc(valueA, valueB)
           }

--- a/assets/js/mojSortableTable.js
+++ b/assets/js/mojSortableTable.js
@@ -12,6 +12,10 @@ class PersistentSortOrder {
       this.forceSortOrder(table, sortOrder)
     }
   }
+  static persistCurrentTablePersistentId(tablePersistentId) {
+    const object = { tablePersistentId }
+    window.localStorage.setItem('currentTable', JSON.stringify(object))
+  }
   static createARIASort(from) {
     if (from === 'none' || from === 'ascending' || from === 'descending') {
       return from
@@ -46,7 +50,6 @@ class PersistentSortOrder {
           console.warn('Unrecognised aria-sort attribute')
           return
         }
-        const columnNumber = header.getAttribute('col-number')
         const datePatternForSort = header.getAttribute('date-pattern-for-sort')
         const columnPersistentId = header.dataset.persistentId
         if (columnPersistentId === undefined) {
@@ -55,7 +58,7 @@ class PersistentSortOrder {
         }
         // IE11 doesn't support `.includes`, so we're using `indexOf` here.
         if (['descending', 'ascending'].indexOf(newAriaSort) > -1) {
-          this.persistSortOrder(tablePersistentId, columnPersistentId, newAriaSort, datePatternForSort, columnNumber)
+          this.persistSortOrder(tablePersistentId, columnPersistentId, newAriaSort, datePatternForSort)
         }
       }
     })
@@ -63,10 +66,9 @@ class PersistentSortOrder {
   static sortOrderLocalStorageKey(tablePersistentId) {
     return `sortOrder:${tablePersistentId}`
   }
-
-  static persistSortOrder(tablePersistentId, columnPersistentId, order, datePatternForSort, columnNumber) {
+  static persistSortOrder(tablePersistentId, columnPersistentId, order, datePatternForSort) {
     const key = this.sortOrderLocalStorageKey(tablePersistentId)
-    const object = { columnPersistentId, order, datePatternForSort, columnNumber }
+    const object = { columnPersistentId, order, datePatternForSort }
     window.localStorage.setItem(key, JSON.stringify(object))
   }
   static fetchSortOrderDTO(tablePersistentId) {
@@ -104,12 +106,6 @@ class PersistentSortOrder {
     // Ditto re “not sure why a cast is necessary”
     return withTypedValues
   }
-
-  static persistCurrentTablePersistentId(tablePersistentId) {
-    const object = { tablePersistentId }
-    window.localStorage.setItem('currentTable', JSON.stringify(object))
-  }
-
   static forceSortOrder(table, sortOrder) {
     const headers = table.querySelectorAll('thead th')
     let header

--- a/integration_tests/integration/active-cases.spec.ts
+++ b/integration_tests/integration/active-cases.spec.ts
@@ -1,5 +1,7 @@
 import Page from '../pages/page'
 import ActiveCasesPage from '../pages/activeCases'
+// eslint-disable-next-line import/named
+import { sortDataAndAssertSortExpectations } from './helper/sort-helper'
 
 context('Active Cases', () => {
   let activeCasesPage
@@ -74,23 +76,22 @@ context('Active Cases', () => {
   })
 
   it('should show which column the table is currently sorted by', () => {
-    const headings = ['Name / CRN', 'Tier', 'Type of case']
-    headings.forEach(heading => {
-      cy.get('table').within(() => cy.contains('button', heading).click())
-
-      // check the clicked heading is sorted and all others are not
-      cy.get('thead')
-        .find('th')
-        .each($el => {
-          const sort = $el.text() === heading ? 'ascending' : 'none'
-          cy.wrap($el).should('have.attr', { 'aria-sort': sort })
-        })
-
-      // clicking again sorts in the other direction
-      cy.get('table').within(() => cy.contains('button', heading).click())
-
-      cy.get('table').within(() => cy.contains('button', heading).should('have.attr', { 'aria-sort': 'descending' }))
-    })
+    const sortExpectations = [
+      {
+        columnHeaderName: 'Name / CRN',
+        orderedData: ['CRN111', 'CRN222'],
+      },
+      {
+        columnHeaderName: 'Tier',
+        // tier sorts by tierOrder which is different to the alpha chars below (which is wy B3 comes before A0)
+        orderedData: ['B3', 'A0'],
+      },
+      {
+        columnHeaderName: 'Type of case',
+        orderedData: ['Custody', 'License'],
+      },
+    ]
+    sortDataAndAssertSortExpectations(sortExpectations)
   })
 
   it('persists the sort order when refreshing the page', () => {

--- a/integration_tests/integration/active-cases.spec.ts
+++ b/integration_tests/integration/active-cases.spec.ts
@@ -91,7 +91,7 @@ context('Active Cases', () => {
         orderedData: ['Custody', 'License'],
       },
     ]
-    sortDataAndAssertSortExpectations(sortExpectations)
+    sortDataAndAssertSortExpectations(1, sortExpectations, false)
   })
 
   it('persists the sort order when refreshing the page', () => {

--- a/integration_tests/integration/active-cases.spec.ts
+++ b/integration_tests/integration/active-cases.spec.ts
@@ -76,22 +76,20 @@ context('Active Cases', () => {
   it('should show which column the table is currently sorted by', () => {
     const headings = ['Name / CRN', 'Tier', 'Type of case']
     headings.forEach(heading => {
-      it(`should set headings correctly when sorting by ${heading}`, () => {
-        cy.get('table').within(() => cy.contains('button', heading).click())
+      cy.get('table').within(() => cy.contains('button', heading).click())
 
-        // check the clicked heading is sorted and all others are not
-        cy.get('thead')
-          .find('th')
-          .each($el => {
-            const sort = $el.text() === heading ? 'ascending' : 'none'
-            cy.wrap($el).should('have.attr', { 'aria-sort': sort })
-          })
+      // check the clicked heading is sorted and all others are not
+      cy.get('thead')
+        .find('th')
+        .each($el => {
+          const sort = $el.text() === heading ? 'ascending' : 'none'
+          cy.wrap($el).should('have.attr', { 'aria-sort': sort })
+        })
 
-        // clicking again sorts in the other direction
-        cy.get('table').within(() => cy.contains('button', heading).click())
+      // clicking again sorts in the other direction
+      cy.get('table').within(() => cy.contains('button', heading).click())
 
-        cy.get('table').within(() => cy.contains('button', heading).should('have.attr', { 'aria-sort': 'descending' }))
-      })
+      cy.get('table').within(() => cy.contains('button', heading).should('have.attr', { 'aria-sort': 'descending' }))
     })
   })
 

--- a/integration_tests/integration/choose-practitioner.spec.ts
+++ b/integration_tests/integration/choose-practitioner.spec.ts
@@ -412,22 +412,26 @@ context('Choose Practitioner', () => {
     cy.visit('/pdu/PDU1/J678910/convictions/1/choose-practitioner')
     const headings = ['Name', 'Team', 'Grade', 'Workload %', 'Cases in past 7 days', 'Community cases', 'Custody cases']
     headings.forEach(heading => {
-      it(`should set headings correctly when sorting by ${heading}`, () => {
-        cy.get('table').within(() => cy.contains('button', heading).click())
+      cy.get('table')
+        .eq(0)
+        .within(() => cy.contains('button', heading).click())
 
-        // check the clicked heading is sorted and all others are not
-        cy.get('thead')
-          .find('th')
-          .each($el => {
-            const sort = $el.text() === heading ? 'ascending' : 'none'
-            cy.wrap($el).should('have.attr', { 'aria-sort': sort })
-          })
+      // check the clicked heading is sorted and all others are not
+      cy.get('thead')
+        .find('th')
+        .each($el => {
+          const sort = $el.text() === heading ? 'ascending' : 'none'
+          cy.wrap($el).should('have.attr', { 'aria-sort': sort })
+        })
 
-        // clicking again sorts in the other direction
-        cy.get('table').within(() => cy.contains('button', heading).click())
+      // clicking again sorts in the other direction
+      cy.get('table')
+        .eq(0)
+        .within(() => cy.contains('button', heading).click())
 
-        cy.get('table').within(() => cy.contains('button', heading).should('have.attr', { 'aria-sort': 'descending' }))
-      })
+      cy.get('table')
+        .eq(0)
+        .within(() => cy.contains('button', heading).should('have.attr', { 'aria-sort': 'descending' }))
     })
   })
 

--- a/integration_tests/integration/choose-practitioner.spec.ts
+++ b/integration_tests/integration/choose-practitioner.spec.ts
@@ -1,6 +1,7 @@
 import Page from '../pages/page'
 import ChoosePractitionerPage from '../pages/choosePractitioner'
 import SummaryPage from '../pages/summary'
+import { sortDataAndAssertSortExpectations } from './helper/sort-helper'
 
 context('Choose Practitioner', () => {
   beforeEach(() => {
@@ -410,29 +411,38 @@ context('Choose Practitioner', () => {
   it('should show which column the choose-practitioner table is currently sorted by', () => {
     cy.signIn()
     cy.visit('/pdu/PDU1/J678910/convictions/1/choose-practitioner')
-    const headings = ['Name', 'Team', 'Grade', 'Workload %', 'Cases in past 7 days', 'Community cases', 'Custody cases']
-    headings.forEach(heading => {
-      cy.get('table')
-        .eq(0)
-        .within(() => cy.contains('button', heading).click())
-
-      // check the clicked heading is sorted and all others are not
-      cy.get('thead')
-        .find('th')
-        .each($el => {
-          const sort = $el.text() === heading ? 'ascending' : 'none'
-          cy.wrap($el).should('have.attr', { 'aria-sort': sort })
-        })
-
-      // clicking again sorts in the other direction
-      cy.get('table')
-        .eq(0)
-        .within(() => cy.contains('button', heading).click())
-
-      cy.get('table')
-        .eq(0)
-        .within(() => cy.contains('button', heading).should('have.attr', { 'aria-sort': 'descending' }))
-    })
+    const sortExpectations = [
+      {
+        columnHeaderName: 'Name',
+        orderedData: ['Jane Doe', 'Jim Jam', 'Sam Smam'],
+      },
+      {
+        columnHeaderName: 'Team',
+        orderedData: ['Team 1', 'Team 2', 'Team 2'],
+      },
+      {
+        columnHeaderName: 'Grade',
+        // grade is not sorted by the alpha results listed below - it is sorted by gradeOrder (to avoid confusion here)
+        orderedData: ['SPO', 'PQiP', 'PO'],
+      },
+      {
+        columnHeaderName: 'Workload %',
+        orderedData: ['19%', '32%', '32%'],
+      },
+      {
+        columnHeaderName: 'Cases in past 7 days',
+        orderedData: ['2', '5', '5'],
+      },
+      {
+        columnHeaderName: 'Community cases',
+        orderedData: ['0', '0', '3'],
+      },
+      {
+        columnHeaderName: 'Custody cases',
+        orderedData: ['5', '5', '5'],
+      },
+    ]
+    sortDataAndAssertSortExpectations(2, sortExpectations, true)
   })
 
   it('persists the sort order of the selected column when refreshing the page', () => {

--- a/integration_tests/integration/documents.spec.ts
+++ b/integration_tests/integration/documents.spec.ts
@@ -123,24 +123,22 @@ context('Documents', () => {
   })
 
   it('should show which column the table is currently sorted by', () => {
-    const headings = ['Name', 'Type', 'Event', 'Date&nbsp;created']
+    const headings = ['Name', 'Type', 'Event', 'Date created']
     headings.forEach(heading => {
-      it(`should set headings correctly when sorting by ${heading}`, () => {
-        cy.get('table').within(() => cy.contains('button', heading).click())
+      cy.get('table').within(() => cy.contains('button', heading).click())
 
-        // check the clicked heading is sorted and all others are not
-        cy.get('thead')
-          .find('th')
-          .each($el => {
-            const sort = $el.text() === heading ? 'ascending' : 'none'
-            cy.wrap($el).should('have.attr', { 'aria-sort': sort })
-          })
+      // check the clicked heading is sorted and all others are not
+      cy.get('thead')
+        .find('th')
+        .each($el => {
+          const sort = $el.text() === heading ? 'ascending' : 'none'
+          cy.wrap($el).should('have.attr', { 'aria-sort': sort })
+        })
 
-        // clicking again sorts in the other direction
-        cy.get('table').within(() => cy.contains('button', heading).click())
+      // clicking again sorts in the other direction
+      cy.get('table').within(() => cy.contains('button', heading).click())
 
-        cy.get('table').within(() => cy.contains('button', heading).should('have.attr', { 'aria-sort': 'descending' }))
-      })
+      cy.get('table').within(() => cy.contains('button', heading).should('have.attr', { 'aria-sort': 'descending' }))
     })
   })
 

--- a/integration_tests/integration/documents.spec.ts
+++ b/integration_tests/integration/documents.spec.ts
@@ -155,7 +155,7 @@ context('Documents', () => {
         orderedData: ['', '', '16 Oct 2021', '7 Nov 2021', '7 Dec 2021'],
       },
     ]
-    sortDataAndAssertSortExpectations(sortExpectations)
+    sortDataAndAssertSortExpectations(1, sortExpectations, false)
   })
 
   it('persists sort order when refreshing the page', () => {

--- a/integration_tests/integration/documents.spec.ts
+++ b/integration_tests/integration/documents.spec.ts
@@ -1,6 +1,8 @@
 import Page from '../pages/page'
 import DocumentsPage from '../pages/documents'
 import outOfAreasBannerBlurb from '../constants'
+// eslint-disable-next-line import/named
+import { sortDataAndAssertSortExpectations } from './helper/sort-helper'
 
 context('Documents', () => {
   beforeEach(() => {
@@ -123,23 +125,37 @@ context('Documents', () => {
   })
 
   it('should show which column the table is currently sorted by', () => {
-    const headings = ['Name', 'Type', 'Event', 'Date created']
-    headings.forEach(heading => {
-      cy.get('table').within(() => cy.contains('button', heading).click())
-
-      // check the clicked heading is sorted and all others are not
-      cy.get('thead')
-        .find('th')
-        .each($el => {
-          const sort = $el.text() === heading ? 'ascending' : 'none'
-          cy.wrap($el).should('have.attr', { 'aria-sort': sort })
-        })
-
-      // clicking again sorts in the other direction
-      cy.get('table').within(() => cy.contains('button', heading).click())
-
-      cy.get('table').within(() => cy.contains('button', heading).should('have.attr', { 'aria-sort': 'descending' }))
-    })
+    const sortExpectations = [
+      {
+        columnHeaderName: 'Name',
+        orderedData: [
+          // todo: someone could look into this? Problem outlined....
+          // this column does not specify a "data-sort-value" attribute in "documents.njk" and so it just sorts the html value in the table's column cell
+          // as a result, the sort basically does not work
+          // I assume this was intentional for some reason??
+          // for example, a fix could be to pass "document.fileName" as the "data-sort-value" attribute but perhaps this data field is unreliable and do not want to mess with production code and cause problems
+        ],
+      },
+      {
+        columnHeaderName: 'Type',
+        orderedData: [
+          'Planned Office Visit (NS)',
+          'Planned Office Visit (NS)',
+          'Pre Cons',
+          'Pre-Sentence Report - Fast',
+          'SA2020 Suspended Sentence Order',
+        ],
+      },
+      {
+        columnHeaderName: 'Event',
+        orderedData: ['Current', 'Not attached to an event', 'Previous', 'Previous', 'Previous'],
+      },
+      {
+        columnHeaderName: 'Date created',
+        orderedData: ['', '', '16 Oct 2021', '7 Nov 2021', '7 Dec 2021'],
+      },
+    ]
+    sortDataAndAssertSortExpectations(sortExpectations)
   })
 
   it('persists sort order when refreshing the page', () => {

--- a/integration_tests/integration/find-unallocated-cases.spec.ts
+++ b/integration_tests/integration/find-unallocated-cases.spec.ts
@@ -178,7 +178,7 @@ context('Find Unallocated cases', () => {
         {
           'Name / CRN': 'Sofia MitchellL786545',
           Tier: 'C1',
-          'Sentence date': '1 September 2021',
+          'Sentence date': '10 May 2021',
           'COM Handover date': '3 January 2025',
           'Initial appointment date': 'Not neededCustody case (5 Years)',
           'Probation status': 'Previously managed(John Agard)',
@@ -186,39 +186,39 @@ context('Find Unallocated cases', () => {
         {
           'Name / CRN': 'John SmithP125643',
           Tier: 'C3',
-          'Sentence date': '23 July 2021',
+          'Sentence date': '23 July 2023',
           'COM Handover date': 'N/A',
-          'Initial appointment date': '1 September 2021Reece John Spears',
+          'Initial appointment date': '1 September 2023Reece John Spears',
           'Probation status': 'New to probation',
         },
         {
           'Name / CRN': 'Kacey RayE124321',
           Tier: 'C2',
-          'Sentence date': '1 September 2021',
+          'Sentence date': '16 February 2022',
           'COM Handover date': 'N/A',
-          'Initial appointment date': '2 September 2021Micheala Smith',
+          'Initial appointment date': '25 March 2022Micheala Smith',
           'Probation status': 'New to probation',
         },
         {
           'Name / CRN': 'Andrew WilliamsP567654',
           Tier: 'C1',
-          'Sentence date': '1 September 2021',
+          'Sentence date': '1 June 2021',
           'COM Handover date': 'N/A',
-          'Initial appointment date': '3 September 2021John Paul Tinker',
+          'Initial appointment date': '15 June 2021John Paul Tinker',
           'Probation status': 'Previously managed',
         },
         {
           'Name / CRN': 'Sarah SiddallC567654',
           Tier: 'C2',
-          'Sentence date': '1 September 2021',
+          'Sentence date': '1 March 2024',
           'COM Handover date': 'N/A',
-          'Initial appointment date': '1 September 2021Lando Nickson',
+          'Initial appointment date': '25 April 2024Lando Nickson',
           'Probation status': 'Previously managed',
         },
         {
           'Name / CRN': 'Mick JonesC234432',
           Tier: 'C1',
-          'Sentence date': '25 August 2021',
+          'Sentence date': '25 May 2021',
           'COM Handover date': 'N/A',
           'Initial appointment date': 'Not foundCheck with your team',
           'Probation status': 'Previously managed',
@@ -226,9 +226,9 @@ context('Find Unallocated cases', () => {
         {
           'Name / CRN': 'Bill TurnerF5635632',
           Tier: 'D1',
-          'Sentence date': '1 September 2021',
+          'Sentence date': '10 May 2021',
           'COM Handover date': 'N/A',
-          'Initial appointment date': '1 September 2021Emma Marie Williams',
+          'Initial appointment date': '21 August 2021Emma Marie Williams',
           'Probation status': 'Currently managed(Richard Moore)',
         },
         {
@@ -314,14 +314,77 @@ context('Find Unallocated cases', () => {
     cy.url().should('contain', 'pdu/PDU1/case-allocation-history')
   })
 
+  const generateSortExpectations = () => {
+    const sortExpectations = new Map<string, Array<string>>()
+    sortExpectations.set('Name / CRN', [
+      'C234432',
+      'C567654',
+      'E124321',
+      'F5635632',
+      'J678910',
+      'L786545',
+      'P125643',
+      'P567654',
+      'X768522',
+    ])
+    sortExpectations.set('Tier', ['D1', 'C1', 'C1', 'C1', 'C1', 'C1', 'C2', 'C2', 'C3'])
+    sortExpectations.set('Sentence date', [
+      '1 March 2000',
+      '10 May 2021',
+      '10 May 2021',
+      '25 May 2021',
+      '1 June 2021',
+      '1 September 2021',
+      '16 February 2022',
+      '23 July 2023',
+      '1 March 2024',
+    ])
+    sortExpectations.set('COM Handover date', [
+      '3 October 2024',
+      '3 January 2025',
+      'N/A',
+      'N/A',
+      'N/A',
+      'N/A',
+      'N/A',
+      'N/A',
+      'N/A',
+    ])
+    sortExpectations.set('Initial appointment date', [
+      '15 June 2021',
+      '21 August 2021',
+      '1 September 2021',
+      '25 March 2022',
+      '1 September 2023',
+      '25 April 2024',
+      'Not',
+      'Not',
+      'Not',
+    ])
+    sortExpectations.set('Probation status', [
+      'Currently managed',
+      'Currently managed',
+      'New to probation',
+      'New to probation',
+      'Previously managed',
+      'Previously managed',
+      'Previously managed',
+      'Previously managed',
+      'Previously managed',
+    ])
+    return sortExpectations
+  }
+
   it('should show the column the table is currently sorted by', () => {
     cy.task('stubUserPreferenceAllocationDemand', { pduCode: 'PDU1', lduCode: 'LDU1', teamCode: 'TM1' })
     cy.task('stubGetAllocationsByTeam', { teamCode: 'TM1' })
     cy.reload()
     cy.get('table').within(() => cy.contains('button', 'Name / CRN'))
 
-    const headings = ['Name / CRN', 'Tier', 'Sentence date', 'Initial appointment date', 'Probation status']
-    headings.forEach(heading => {
+    let columnNumber = 1
+    const sortExpectations = generateSortExpectations()
+    sortExpectations.forEach((expectedOrderedColumnValues: Array<string>, key: string) => {
+      const heading = key
       cy.get('table').within(() => cy.contains('button', heading).click())
 
       // check the clicked heading is sorted and all others are not
@@ -332,10 +395,32 @@ context('Find Unallocated cases', () => {
           cy.wrap($el).should('have.attr', { 'aria-sort': sort })
         })
 
+      // checks data for column is sorted ascending
+      let rowNumber = 0
+      expectedOrderedColumnValues.forEach(expectedValue => {
+        cy.get(`tr td:nth-child(${columnNumber})`) // gets the 1st column
+          .eq(rowNumber) // grabs the 2nd row of that column
+          .contains(expectedValue) // asserts expectedColumnValue
+
+        rowNumber += 1
+      })
+
       // clicking again sorts in the other direction
       cy.get('table').within(() => cy.contains('button', heading).click())
-
       cy.get('table').within(() => cy.contains('button', heading).should('have.attr', { 'aria-sort': 'descending' }))
+
+      // checks data for column is sorted descending
+      rowNumber = 0
+      const expectedReverseOrderColumnValues = expectedOrderedColumnValues.reverse()
+      expectedReverseOrderColumnValues.forEach(expectedValue => {
+        cy.get(`tr td:nth-child(${columnNumber})`) // gets the 1st column
+          .eq(rowNumber) // grabs the 2nd row of that column
+          .contains(expectedValue) // asserts expectedColumnValue
+
+        rowNumber += 1
+      })
+
+      columnNumber += 1
     })
   })
 

--- a/integration_tests/integration/find-unallocated-cases.spec.ts
+++ b/integration_tests/integration/find-unallocated-cases.spec.ts
@@ -2,6 +2,7 @@ import FindUnallocatedPage from '../pages/findUnallocatedCases'
 import Page from '../pages/page'
 
 import config from '../../server/config'
+import { allocationsByTeamResponse } from '../mockApis/allocations'
 
 context('Find Unallocated cases', () => {
   let findUnallocatedCasesPage: FindUnallocatedPage
@@ -131,8 +132,37 @@ context('Find Unallocated cases', () => {
   })
 
   it('retrieve allocation demand for team saved in user preference allocation demand', () => {
+    const outOfAreaTransferCase = {
+      name: 'John Doe',
+      crn: 'X678911',
+      tier: 'C1',
+      sentenceDate: '2023-12-01',
+      handoverDate: null,
+      initialAppointment: {
+        date: '2023-12-20',
+        staff: {
+          name: {
+            forename: 'Unallocated',
+            middlename: null,
+            surname: 'Staff',
+            combinedName: 'Unallocated Staff',
+          },
+        },
+      },
+      status: 'Currently managed',
+      offenderManager: {
+        forenames: 'Jane',
+        surname: 'Doe',
+        grade: 'SPO',
+      },
+      convictionNumber: 1,
+      caseType: 'COMMUNITY',
+      outOfAreaTransfer: true,
+    }
     cy.task('stubUserPreferenceAllocationDemand', { pduCode: 'PDU1', lduCode: 'LDU1', teamCode: 'TM1' })
-    cy.task('stubGetAllocationsByTeam', { teamCode: 'TM1' })
+    const response = allocationsByTeamResponse
+    response.push(outOfAreaTransferCase)
+    cy.task('stubGetAllocationsByTeam', { teamCode: 'TM1', response })
     cy.reload()
     cy.get('table')
       .getTable()
@@ -141,27 +171,23 @@ context('Find Unallocated cases', () => {
           'Name / CRN': 'Dylan Adam ArmstrongJ678910',
           Tier: 'C1',
           'Sentence date': '1 September 2021',
+          'COM Handover date': 'N/A',
           'Initial appointment date': '1 September 2021Unallocated officer',
           'Probation status': 'Currently managed(Antonio LoSardo, SPO)',
-        },
-        {
-          'Name / CRN': 'John DoeX678911  Actionrequired',
-          Tier: 'C1',
-          'Sentence date': '1 December 2023',
-          'Initial appointment date':
-            'This case is sitting in a different area, and the transfer process must be completed in NDelius before it can be allocated through the service. You can still review the case details.',
         },
         {
           'Name / CRN': 'Sofia MitchellL786545',
           Tier: 'C1',
           'Sentence date': '1 September 2021',
-          'Initial appointment date': 'Not neededCustody case (32 Years)',
+          'COM Handover date': '3 January 2025',
+          'Initial appointment date': 'Not neededCustody case (5 Years)',
           'Probation status': 'Previously managed(John Agard)',
         },
         {
           'Name / CRN': 'John SmithP125643',
           Tier: 'C3',
           'Sentence date': '23 July 2021',
+          'COM Handover date': 'N/A',
           'Initial appointment date': '1 September 2021Reece John Spears',
           'Probation status': 'New to probation',
         },
@@ -169,6 +195,7 @@ context('Find Unallocated cases', () => {
           'Name / CRN': 'Kacey RayE124321',
           Tier: 'C2',
           'Sentence date': '1 September 2021',
+          'COM Handover date': 'N/A',
           'Initial appointment date': '2 September 2021Micheala Smith',
           'Probation status': 'New to probation',
         },
@@ -176,6 +203,7 @@ context('Find Unallocated cases', () => {
           'Name / CRN': 'Andrew WilliamsP567654',
           Tier: 'C1',
           'Sentence date': '1 September 2021',
+          'COM Handover date': 'N/A',
           'Initial appointment date': '3 September 2021John Paul Tinker',
           'Probation status': 'Previously managed',
         },
@@ -183,6 +211,7 @@ context('Find Unallocated cases', () => {
           'Name / CRN': 'Sarah SiddallC567654',
           Tier: 'C2',
           'Sentence date': '1 September 2021',
+          'COM Handover date': 'N/A',
           'Initial appointment date': '1 September 2021Lando Nickson',
           'Probation status': 'Previously managed',
         },
@@ -190,6 +219,7 @@ context('Find Unallocated cases', () => {
           'Name / CRN': 'Mick JonesC234432',
           Tier: 'C1',
           'Sentence date': '25 August 2021',
+          'COM Handover date': 'N/A',
           'Initial appointment date': 'Not foundCheck with your team',
           'Probation status': 'Previously managed',
         },
@@ -197,8 +227,25 @@ context('Find Unallocated cases', () => {
           'Name / CRN': 'Bill TurnerF5635632',
           Tier: 'D1',
           'Sentence date': '1 September 2021',
+          'COM Handover date': 'N/A',
           'Initial appointment date': '1 September 2021Emma Marie Williams',
           'Probation status': 'Currently managed(Richard Moore)',
+        },
+        {
+          'Name / CRN': 'Daffy DuckX768522',
+          Tier: 'C1',
+          'Sentence date': '1 March 2000',
+          'COM Handover date': '3 October 2024',
+          'Initial appointment date': 'Not neededCustody case (25 Years)',
+          'Probation status': 'Previously managed(John Agard)',
+        },
+        {
+          'Name / CRN': 'John DoeX678911  Actionrequired',
+          Tier: 'C1',
+          'Sentence date': '1 December 2023',
+          'COM Handover date': 'N/A',
+          'Initial appointment date':
+            'This case is sitting in a different area, and the transfer process must be completed in NDelius before it can be allocated through the service. You can still review the case details.',
         },
       ])
   })
@@ -271,24 +318,24 @@ context('Find Unallocated cases', () => {
     cy.task('stubUserPreferenceAllocationDemand', { pduCode: 'PDU1', lduCode: 'LDU1', teamCode: 'TM1' })
     cy.task('stubGetAllocationsByTeam', { teamCode: 'TM1' })
     cy.reload()
+    cy.get('table').within(() => cy.contains('button', 'Name / CRN'))
+
     const headings = ['Name / CRN', 'Tier', 'Sentence date', 'Initial appointment date', 'Probation status']
     headings.forEach(heading => {
-      it(`should set headings correctly when sorting by ${heading}`, () => {
-        cy.get('table').within(() => cy.contains('button', heading).click())
+      cy.get('table').within(() => cy.contains('button', heading).click())
 
-        // check the clicked heading is sorted and all others are not
-        cy.get('thead')
-          .find('th')
-          .each($el => {
-            const sort = $el.text() === heading ? 'ascending' : 'none'
-            cy.wrap($el).should('have.attr', { 'aria-sort': sort })
-          })
+      // check the clicked heading is sorted and all others are not
+      cy.get('thead')
+        .find('th')
+        .each($el => {
+          const sort = $el.text() === heading ? 'ascending' : 'none'
+          cy.wrap($el).should('have.attr', { 'aria-sort': sort })
+        })
 
-        // clicking again sorts in the other direction
-        cy.get('table').within(() => cy.contains('button', heading).click())
+      // clicking again sorts in the other direction
+      cy.get('table').within(() => cy.contains('button', heading).click())
 
-        cy.get('table').within(() => cy.contains('button', heading).should('have.attr', { 'aria-sort': 'descending' }))
-      })
+      cy.get('table').within(() => cy.contains('button', heading).should('have.attr', { 'aria-sort': 'descending' }))
     })
   })
 

--- a/integration_tests/integration/find-unallocated-cases.spec.ts
+++ b/integration_tests/integration/find-unallocated-cases.spec.ts
@@ -394,7 +394,7 @@ context('Find Unallocated cases', () => {
     cy.get('table').within(() => cy.contains('button', 'Name / CRN'))
 
     const sortExpectations = generateSortExpectations()
-    sortDataAndAssertSortExpectations(sortExpectations)
+    sortDataAndAssertSortExpectations(1, sortExpectations, false)
   })
 
   it('persists sort order when refreshing the page', () => {

--- a/integration_tests/integration/helper/sort-helper.ts
+++ b/integration_tests/integration/helper/sort-helper.ts
@@ -3,11 +3,20 @@ export interface ColumnSortExpectations {
   orderedData: Array<string>
 }
 
-export const sortDataAndAssertSortExpectations = (sortExpectations: Array<ColumnSortExpectations>) => {
-  let columnNumber = 1
+export const sortDataAndAssertSortExpectations = (
+  firstSortableColumnNumber: number,
+  sortExpectations: Array<ColumnSortExpectations>,
+  isMultiTabTable: boolean
+) => {
+  let columnNumber = firstSortableColumnNumber
   sortExpectations.forEach(columnSortExpectation => {
-    cy.get('table').within(() => cy.contains('button', columnSortExpectation.columnHeaderName).click())
-
+    if (isMultiTabTable === true) {
+      cy.get('table')
+        .eq(0)
+        .within(() => cy.contains('button', columnSortExpectation.columnHeaderName).click())
+    } else {
+      cy.get('table').within(() => cy.contains('button', columnSortExpectation.columnHeaderName).click())
+    }
     // check the clicked heading is sorted and all others are not
     cy.get('thead')
       .find('th')
@@ -28,10 +37,23 @@ export const sortDataAndAssertSortExpectations = (sortExpectations: Array<Column
     })
 
     // clicking again sorts in the other direction
-    cy.get('table').within(() => cy.contains('button', columnSortExpectation.columnHeaderName).click())
-    cy.get('table').within(() =>
-      cy.contains('button', columnSortExpectation.columnHeaderName).should('have.attr', { 'aria-sort': 'descending' })
-    )
+    if (isMultiTabTable === true) {
+      cy.get('table')
+        .eq(0)
+        .within(() => cy.contains('button', columnSortExpectation.columnHeaderName).click())
+      cy.get('table')
+        .eq(0)
+        .within(() =>
+          cy
+            .contains('button', columnSortExpectation.columnHeaderName)
+            .should('have.attr', { 'aria-sort': 'descending' })
+        )
+    } else {
+      cy.get('table').within(() => cy.contains('button', columnSortExpectation.columnHeaderName).click())
+      cy.get('table').within(() =>
+        cy.contains('button', columnSortExpectation.columnHeaderName).should('have.attr', { 'aria-sort': 'descending' })
+      )
+    }
 
     // checks data for column is sorted descending
     rowNumber = 0

--- a/integration_tests/integration/helper/sort-helper.ts
+++ b/integration_tests/integration/helper/sort-helper.ts
@@ -1,0 +1,50 @@
+export interface ColumnSortExpectations {
+  columnHeaderName: string
+  orderedData: Array<string>
+}
+
+export const sortDataAndAssertSortExpectations = (sortExpectations: Array<ColumnSortExpectations>) => {
+  let columnNumber = 1
+  sortExpectations.forEach(columnSortExpectation => {
+    cy.get('table').within(() => cy.contains('button', columnSortExpectation.columnHeaderName).click())
+
+    // check the clicked heading is sorted and all others are not
+    cy.get('thead')
+      .find('th')
+      .each($el => {
+        const sort = $el.text() === columnSortExpectation.columnHeaderName ? 'ascending' : 'none'
+        cy.wrap($el).should('have.attr', { 'aria-sort': sort })
+      })
+
+    // checks data for column is sorted ascending
+    let rowNumber = 0
+    columnSortExpectation.orderedData.forEach(expectedData => {
+      if (expectedData) {
+        cy.get(`tr td:nth-child(${columnNumber})`) // gets the 1st column
+          .eq(rowNumber) // grabs the 2nd row of that column
+          .contains(expectedData) // asserts expectedColumnValue
+      }
+      rowNumber += 1
+    })
+
+    // clicking again sorts in the other direction
+    cy.get('table').within(() => cy.contains('button', columnSortExpectation.columnHeaderName).click())
+    cy.get('table').within(() =>
+      cy.contains('button', columnSortExpectation.columnHeaderName).should('have.attr', { 'aria-sort': 'descending' })
+    )
+
+    // checks data for column is sorted descending
+    rowNumber = 0
+    const orderedDataDescending = columnSortExpectation.orderedData.reverse()
+    orderedDataDescending.forEach(expectedData => {
+      if (expectedData) {
+        cy.get(`tr td:nth-child(${columnNumber})`) // gets the 1st column
+          .eq(rowNumber) // grabs the 2nd row of that column
+          .contains(expectedData) // asserts expectedColumnValue
+      }
+      rowNumber += 1
+    })
+
+    columnNumber += 1
+  })
+}

--- a/integration_tests/mockApis/allocations.ts
+++ b/integration_tests/mockApis/allocations.ts
@@ -1,200 +1,198 @@
 import { SuperAgentRequest } from 'superagent'
 import { stubForAllocation } from './wiremock'
 
+export const allocationsByTeamResponse = [
+  {
+    name: 'Dylan Adam Armstrong',
+    crn: 'J678910',
+    tier: 'C1',
+    sentenceDate: '2021-09-01',
+    handoverDate: null,
+    initialAppointment: {
+      date: '2021-09-01',
+      staff: {
+        name: {
+          forename: 'Unallocated',
+          middlename: null,
+          surname: 'Staff',
+          combinedName: 'Unallocated Staff',
+        },
+      },
+    },
+    status: 'Currently managed',
+    offenderManager: {
+      forenames: 'Antonio',
+      surname: 'LoSardo',
+      grade: 'SPO',
+    },
+    convictionNumber: 1,
+    caseType: 'COMMUNITY',
+    outOfAreaTransfer: false,
+  },
+  {
+    name: 'Sofia Mitchell',
+    crn: 'L786545',
+    tier: 'C1',
+    sentenceDate: '2021-09-01',
+    handoverDate: '2025-01-03',
+    initialAppointment: null,
+    status: 'Previously managed',
+    offenderManager: {
+      forenames: 'John',
+      surname: 'Agard',
+    },
+    convictionNumber: 2,
+    caseType: 'CUSTODY',
+    sentenceLength: '5 Years',
+    outOfAreaTransfer: false,
+  },
+  {
+    name: 'John Smith',
+    crn: 'P125643',
+    tier: 'C3',
+    sentenceDate: '2021-07-23',
+    handoverDate: null,
+    initialAppointment: {
+      date: '2021-09-01',
+      staff: {
+        name: {
+          forename: 'Reece',
+          middlename: 'John',
+          surname: 'Spears',
+          combinedName: 'Reece John Spears',
+        },
+      },
+    },
+    status: 'New to probation',
+    convictionNumber: 3,
+    caseType: 'COMMUNITY',
+    outOfAreaTransfer: false,
+  },
+  {
+    name: 'Kacey Ray',
+    crn: 'E124321',
+    tier: 'C2',
+    sentenceDate: '2021-09-01',
+    handoverDate: null,
+    initialAppointment: {
+      date: '2021-09-02',
+      staff: {
+        name: {
+          forename: 'Micheala',
+          middlename: null,
+          surname: 'Smith',
+          combinedName: 'Micheala Smith',
+        },
+      },
+    },
+    status: 'New to probation',
+    convictionNumber: 4,
+    caseType: 'COMMUNITY',
+    outOfAreaTransfer: false,
+  },
+  {
+    name: 'Andrew Williams',
+    crn: 'P567654',
+    tier: 'C1',
+    sentenceDate: '2021-09-01',
+    handoverDate: null,
+    initialAppointment: {
+      date: '2021-09-03',
+      staff: {
+        name: {
+          forename: 'John',
+          middlename: 'Paul',
+          surname: 'Tinker',
+          combinedName: 'John Paul Tinker',
+        },
+      },
+    },
+    status: 'Previously managed',
+    convictionNumber: 5,
+    caseType: 'COMMUNITY',
+    outOfAreaTransfer: false,
+  },
+  {
+    name: 'Sarah Siddall',
+    crn: 'C567654',
+    tier: 'C2',
+    sentenceDate: '2021-09-01',
+    handoverDate: null,
+    initialAppointment: {
+      date: '2021-09-01',
+      staff: {
+        name: {
+          forename: 'Lando',
+          middlename: null,
+          surname: 'Nickson',
+          combinedName: 'Lando Nickson',
+        },
+      },
+    },
+    status: 'Previously managed',
+    convictionNumber: 1,
+    caseType: 'COMMUNITY',
+    outOfAreaTransfer: false,
+  },
+  {
+    name: 'Mick Jones',
+    crn: 'C234432',
+    tier: 'C1',
+    sentenceDate: '2021-08-25',
+    handoverDate: null,
+    initialAppointment: null,
+    status: 'Previously managed',
+    convictionNumber: 6,
+    caseType: 'COMMUNITY',
+    outOfAreaTransfer: false,
+  },
+  {
+    name: 'Bill Turner',
+    crn: 'F5635632',
+    tier: 'D1',
+    sentenceDate: '2021-09-01',
+    handoverDate: null,
+    initialAppointment: {
+      date: '2021-09-01',
+      staff: {
+        name: {
+          forename: 'Emma',
+          middlename: 'Marie',
+          surname: 'Williams',
+          combinedName: 'Emma Marie Williams',
+        },
+      },
+    },
+    status: 'Currently managed',
+    offenderManager: {
+      forenames: 'Richard',
+      surname: 'Moore',
+    },
+    convictionNumber: 7,
+    caseType: 'COMMUNITY',
+    outOfAreaTransfer: false,
+  },
+  {
+    name: 'Daffy Duck',
+    crn: 'X768522',
+    tier: 'C1',
+    sentenceDate: '2000-03-01',
+    handoverDate: '2024-10-03',
+    initialAppointment: null,
+    status: 'Previously managed',
+    offenderManager: {
+      forenames: 'John',
+      surname: 'Agard',
+    },
+    convictionNumber: 2,
+    caseType: 'CUSTODY',
+    sentenceLength: '25 Years',
+    outOfAreaTransfer: false,
+  },
+]
+
 export default {
-  stubGetAllocationsByTeam: ({
-    teamCode,
-    response = [
-      {
-        name: 'Dylan Adam Armstrong',
-        crn: 'J678910',
-        tier: 'C1',
-        sentenceDate: '2021-09-01',
-        initialAppointment: {
-          date: '2021-09-01',
-          staff: {
-            name: {
-              forename: 'Unallocated',
-              middlename: null,
-              surname: 'Staff',
-              combinedName: 'Unallocated Staff',
-            },
-          },
-        },
-        status: 'Currently managed',
-        offenderManager: {
-          forenames: 'Antonio',
-          surname: 'LoSardo',
-          grade: 'SPO',
-        },
-        convictionNumber: 1,
-        caseType: 'COMMUNITY',
-        outOfAreaTransfer: false,
-      },
-      {
-        name: 'John Doe',
-        crn: 'X678911',
-        tier: 'C1',
-        sentenceDate: '2023-12-01',
-        initialAppointment: {
-          date: '2023-12-20',
-          staff: {
-            name: {
-              forename: 'Unallocated',
-              middlename: null,
-              surname: 'Staff',
-              combinedName: 'Unallocated Staff',
-            },
-          },
-        },
-        status: 'Currently managed',
-        offenderManager: {
-          forenames: 'Jane',
-          surname: 'Doe',
-          grade: 'SPO',
-        },
-        convictionNumber: 1,
-        caseType: 'COMMUNITY',
-        outOfAreaTransfer: true,
-      },
-      {
-        name: 'Sofia Mitchell',
-        crn: 'L786545',
-        tier: 'C1',
-        sentenceDate: '2021-09-01',
-        initialAppointment: null,
-        status: 'Previously managed',
-        offenderManager: {
-          forenames: 'John',
-          surname: 'Agard',
-        },
-        convictionNumber: 2,
-        caseType: 'CUSTODY',
-        sentenceLength: '32 Years',
-        outOfAreaTransfer: false,
-      },
-      {
-        name: 'John Smith',
-        crn: 'P125643',
-        tier: 'C3',
-        sentenceDate: '2021-07-23',
-        initialAppointment: {
-          date: '2021-09-01',
-          staff: {
-            name: {
-              forename: 'Reece',
-              middlename: 'John',
-              surname: 'Spears',
-              combinedName: 'Reece John Spears',
-            },
-          },
-        },
-        status: 'New to probation',
-        convictionNumber: 3,
-        caseType: 'COMMUNITY',
-        outOfAreaTransfer: false,
-      },
-      {
-        name: 'Kacey Ray',
-        crn: 'E124321',
-        tier: 'C2',
-        sentenceDate: '2021-09-01',
-        initialAppointment: {
-          date: '2021-09-02',
-          staff: {
-            name: {
-              forename: 'Micheala',
-              middlename: null,
-              surname: 'Smith',
-              combinedName: 'Micheala Smith',
-            },
-          },
-        },
-        status: 'New to probation',
-        convictionNumber: 4,
-        caseType: 'COMMUNITY',
-        outOfAreaTransfer: false,
-      },
-      {
-        name: 'Andrew Williams',
-        crn: 'P567654',
-        tier: 'C1',
-        sentenceDate: '2021-09-01',
-        initialAppointment: {
-          date: '2021-09-03',
-          staff: {
-            name: {
-              forename: 'John',
-              middlename: 'Paul',
-              surname: 'Tinker',
-              combinedName: 'John Paul Tinker',
-            },
-          },
-        },
-        status: 'Previously managed',
-        convictionNumber: 5,
-        caseType: 'COMMUNITY',
-        outOfAreaTransfer: false,
-      },
-      {
-        name: 'Sarah Siddall',
-        crn: 'C567654',
-        tier: 'C2',
-        sentenceDate: '2021-09-01',
-        initialAppointment: {
-          date: '2021-09-01',
-          staff: {
-            name: {
-              forename: 'Lando',
-              middlename: null,
-              surname: 'Nickson',
-              combinedName: 'Lando Nickson',
-            },
-          },
-        },
-        status: 'Previously managed',
-        convictionNumber: 1,
-        caseType: 'COMMUNITY',
-        outOfAreaTransfer: false,
-      },
-      {
-        name: 'Mick Jones',
-        crn: 'C234432',
-        tier: 'C1',
-        sentenceDate: '2021-08-25',
-        initialAppointment: null,
-        status: 'Previously managed',
-        convictionNumber: 6,
-        caseType: 'COMMUNITY',
-        outOfAreaTransfer: false,
-      },
-      {
-        name: 'Bill Turner',
-        crn: 'F5635632',
-        tier: 'D1',
-        sentenceDate: '2021-09-01',
-        initialAppointment: {
-          date: '2021-09-01',
-          staff: {
-            name: {
-              forename: 'Emma',
-              middlename: 'Marie',
-              surname: 'Williams',
-              combinedName: 'Emma Marie Williams',
-            },
-          },
-        },
-        status: 'Currently managed',
-        offenderManager: {
-          forenames: 'Richard',
-          surname: 'Moore',
-        },
-        convictionNumber: 7,
-        caseType: 'COMMUNITY',
-        outOfAreaTransfer: false,
-      },
-    ],
-  }): SuperAgentRequest => {
+  stubGetAllocationsByTeam: ({ teamCode, response = allocationsByTeamResponse }): SuperAgentRequest => {
     return stubForAllocation({
       request: {
         method: 'GET',

--- a/integration_tests/mockApis/allocations.ts
+++ b/integration_tests/mockApis/allocations.ts
@@ -33,7 +33,7 @@ export const allocationsByTeamResponse = [
     name: 'Sofia Mitchell',
     crn: 'L786545',
     tier: 'C1',
-    sentenceDate: '2021-09-01',
+    sentenceDate: '2021-05-10',
     handoverDate: '2025-01-03',
     initialAppointment: null,
     status: 'Previously managed',
@@ -50,10 +50,10 @@ export const allocationsByTeamResponse = [
     name: 'John Smith',
     crn: 'P125643',
     tier: 'C3',
-    sentenceDate: '2021-07-23',
+    sentenceDate: '2023-07-23',
     handoverDate: null,
     initialAppointment: {
-      date: '2021-09-01',
+      date: '2023-09-01',
       staff: {
         name: {
           forename: 'Reece',
@@ -72,10 +72,10 @@ export const allocationsByTeamResponse = [
     name: 'Kacey Ray',
     crn: 'E124321',
     tier: 'C2',
-    sentenceDate: '2021-09-01',
+    sentenceDate: '2022-02-16',
     handoverDate: null,
     initialAppointment: {
-      date: '2021-09-02',
+      date: '2022-03-25',
       staff: {
         name: {
           forename: 'Micheala',
@@ -94,10 +94,10 @@ export const allocationsByTeamResponse = [
     name: 'Andrew Williams',
     crn: 'P567654',
     tier: 'C1',
-    sentenceDate: '2021-09-01',
+    sentenceDate: '2021-06-01',
     handoverDate: null,
     initialAppointment: {
-      date: '2021-09-03',
+      date: '2021-06-15',
       staff: {
         name: {
           forename: 'John',
@@ -116,10 +116,10 @@ export const allocationsByTeamResponse = [
     name: 'Sarah Siddall',
     crn: 'C567654',
     tier: 'C2',
-    sentenceDate: '2021-09-01',
+    sentenceDate: '2024-03-01',
     handoverDate: null,
     initialAppointment: {
-      date: '2021-09-01',
+      date: '2024-04-25',
       staff: {
         name: {
           forename: 'Lando',
@@ -138,7 +138,7 @@ export const allocationsByTeamResponse = [
     name: 'Mick Jones',
     crn: 'C234432',
     tier: 'C1',
-    sentenceDate: '2021-08-25',
+    sentenceDate: '2021-05-25',
     handoverDate: null,
     initialAppointment: null,
     status: 'Previously managed',
@@ -150,10 +150,10 @@ export const allocationsByTeamResponse = [
     name: 'Bill Turner',
     crn: 'F5635632',
     tier: 'D1',
-    sentenceDate: '2021-09-01',
+    sentenceDate: '2021-05-10',
     handoverDate: null,
     initialAppointment: {
-      date: '2021-09-01',
+      date: '2021-08-21',
       staff: {
         name: {
           forename: 'Emma',

--- a/server/controllers/data/UnallocatedCase.ts
+++ b/server/controllers/data/UnallocatedCase.ts
@@ -71,24 +71,9 @@ export default class UnallocatedCase {
     return ''
   }
 
-  getRandomInt(max: number) {
-    return Math.floor(Math.random() * max)
-  }
-
-  addDays(days: number) {
-    const date = new Date()
-    date.setDate(date.getDate() + days)
-    return date
-  }
-
   setHandoverDate(handoverDate: string) {
-    const zeroOrOne = this.getRandomInt(2)
-    if (zeroOrOne === 0) {
-      const addedDays = this.getRandomInt(10) * this.getRandomInt(5)
-      const randomFutureDate = this.addDays(addedDays)
-      const here = randomFutureDate.getTime() - randomFutureDate.getTimezoneOffset() * 60000
-      const dummyHandoverDateString = new Date(here).toISOString().split('T')[0]
-      this.handoverDate = `${dayjs(dummyHandoverDateString).format(config.dateFormat)}`
+    if (handoverDate) {
+      this.handoverDate = `${dayjs(handoverDate).format(config.dateFormat)}`
     } else {
       this.handoverDate = 'N/A'
     }

--- a/server/controllers/data/UnallocatedCase.ts
+++ b/server/controllers/data/UnallocatedCase.ts
@@ -90,7 +90,7 @@ export default class UnallocatedCase {
       const dummyHandoverDateString = new Date(here).toISOString().split('T')[0]
       this.handoverDate = `${dayjs(dummyHandoverDateString).format(config.dateFormat)}`
     } else {
-      this.handoverDate = `${dayjs('1970-01-01').format(config.dateFormat)}`
+      this.handoverDate = 'N/A'
     }
   }
 

--- a/server/controllers/data/UnallocatedCase.ts
+++ b/server/controllers/data/UnallocatedCase.ts
@@ -37,7 +37,7 @@ export default class UnallocatedCase {
     crn: string,
     tier: string,
     sentenceDate: string,
-    handoverDate: string | undefined,
+    handoverDate: string,
     initialAppointment: InitialAppointment,
     primaryStatus: string,
     offenderManager: OffenderManager,

--- a/server/controllers/data/UnallocatedCase.ts
+++ b/server/controllers/data/UnallocatedCase.ts
@@ -16,6 +16,8 @@ export default class UnallocatedCase {
 
   sentenceDate: string
 
+  handoverDate: string
+
   primaryInitialAppointment: string
 
   secondaryInitialAppointment: string
@@ -35,6 +37,7 @@ export default class UnallocatedCase {
     crn: string,
     tier: string,
     sentenceDate: string,
+    handoverDate: string | undefined,
     initialAppointment: InitialAppointment,
     primaryStatus: string,
     offenderManager: OffenderManager,
@@ -48,6 +51,7 @@ export default class UnallocatedCase {
     this.tier = tier
     this.tierOrder = tierOrder(tier)
     this.sentenceDate = sentenceDate
+    this.setHandoverDate(handoverDate)
     this.setInitialAppointment(initialAppointment, caseType, sentenceLength)
     this.initialAppointment = initialAppointment
     this.primaryStatus = primaryStatus
@@ -65,6 +69,29 @@ export default class UnallocatedCase {
       return `, ${grade}`
     }
     return ''
+  }
+
+  getRandomInt(max: number) {
+    return Math.floor(Math.random() * max)
+  }
+
+  addDays(days: number) {
+    const date = new Date()
+    date.setDate(date.getDate() + days)
+    return date
+  }
+
+  setHandoverDate(handoverDate: string) {
+    const zeroOrOne = this.getRandomInt(2)
+    if (zeroOrOne === 0) {
+      const addedDays = this.getRandomInt(10) * this.getRandomInt(5)
+      const randomFutureDate = this.addDays(addedDays)
+      const here = randomFutureDate.getTime() - randomFutureDate.getTimezoneOffset() * 60000
+      const dummyHandoverDateString = new Date(here).toISOString().split('T')[0]
+      this.handoverDate = `${dayjs(dummyHandoverDateString).format(config.dateFormat)}`
+    } else {
+      this.handoverDate = `${dayjs('1970-01-01').format(config.dateFormat)}`
+    }
   }
 
   setInitialAppointment(initialAppointment: InitialAppointment, caseType: string, sentenceLength: string): void {

--- a/server/controllers/findUnallocatedCasesController.ts
+++ b/server/controllers/findUnallocatedCasesController.ts
@@ -52,6 +52,7 @@ export default class FindUnallocatedCasesController {
           value.crn,
           value.tier,
           value.sentenceDate,
+          value.handoverDate,
           value.initialAppointment,
           value.status,
           value.offenderManager,

--- a/server/models/UnallocatedCase.ts
+++ b/server/models/UnallocatedCase.ts
@@ -6,6 +6,7 @@ export default interface UnallocatedCase {
   crn: string
   tier: string
   sentenceDate: string
+  handoverDate: string | undefined
   initialAppointment: InitialAppointment
   status: string
   offenderManager: OffenderManager

--- a/server/views/pages/active-cases.njk
+++ b/server/views/pages/active-cases.njk
@@ -39,7 +39,10 @@
 
 {% for item in cases %}
     {%- set tableRow = [
-        { text: doubleCell('<strong>' + item.name + '</strong>', item.crn, 'govuk-body-s' )},
+        {
+            text: doubleCell('<strong>' + item.name + '</strong>', item.crn, 'govuk-body-s' ),
+            attributes: { "data-sort-value": item.crn }
+        },
         { text: item.tier, attributes: { "data-sort-value": item.tierOrder } },
         { text: (item.type | capitalize)}
     ] -%}

--- a/server/views/pages/documents.njk
+++ b/server/views/pages/documents.njk
@@ -28,7 +28,7 @@
                 'data-persistent-id': 'documents-event'
             }
         },
-        { html: 'Date&nbsp;created',
+        { html: 'Date created',
             attributes: {
                 "aria-sort": "descending",
                 'data-persistent-id': 'documents-date-created'

--- a/server/views/pages/find-unallocated-cases.njk
+++ b/server/views/pages/find-unallocated-cases.njk
@@ -14,21 +14,18 @@
     head: [
         { text: 'Name / CRN',
             attributes: {
-                "col-number": "1",
                 "aria-sort": "none",
                 'data-persistent-id': 'find-unallocated-cases-name-crn'
             }
         },
         { text: 'Tier',
             attributes: {
-                "col-number": "2",
                 "aria-sort": "none",
                 'data-persistent-id': 'find-unallocated-cases-tier'
             }
         },
         { text: 'Sentence date',
             attributes: {
-                "col-number": "3",
                 "aria-sort": "none",
                 'data-persistent-id': 'find-unallocated-cases-sentence-date',
                 "date-pattern-for-sort": 'YY-MM-YYYY'
@@ -36,7 +33,6 @@
         },
         { text: 'COM Handover date',
             attributes: {
-                "col-number": "4",
                 "aria-sort": "none",
                 'data-persistent-id': 'find-unallocated-cases-handover-date',
                 "date-pattern-for-sort": 'YY-MM-YYYY'
@@ -44,7 +40,6 @@
         },
         { text: 'Initial appointment date',
             attributes: {
-                "col-number": "5",
                 "aria-sort": "none",
                 'data-persistent-id': 'find-unallocated-cases-appointment-date',
                 "date-pattern-for-sort": 'YY-MM-YYYY'
@@ -52,7 +47,6 @@
         },
         { text: 'Probation status',
             attributes: {
-                "col-number": "6",
                 "aria-sort": "none",
                 'data-persistent-id': 'find-unallocated-cases-probation-status'
             }

--- a/server/views/pages/find-unallocated-cases.njk
+++ b/server/views/pages/find-unallocated-cases.njk
@@ -42,7 +42,7 @@
             attributes: {
                 "aria-sort": "none",
                 'data-persistent-id': 'find-unallocated-cases-appointment-date',
-                "data-type": 'DATE_ON_FIRST_LINE'
+                "data-type": 'DATE'
             }
         },
         { text: 'Probation status',
@@ -63,7 +63,9 @@
                 item.crn,
                 'govuk-body-s',
                 '<span><strong class="action-required">Action<br>required</strong></span>'
-            )},
+                ),
+                attributes: { "data-sort-value": item.crn }
+            },
             { text: item.tier, attributes: { "data-sort-value": item.tierOrder } },
             { text: (item.sentenceDate | dateFormat), attributes: {
                 "data-sort-value": item.sentenceDate
@@ -77,13 +79,19 @@
         {{ tableData.rows.push(tableRow) }}
     {% else %}
         {%- set tableRow = [
-            { text: doubleCell('<a href="/pdu/' + pduCode +'/' + item.crn + '/convictions/' + item.convictionNumber +'/case-view" " class="govuk-link--no-visited-state" aria-label="Review case" data-qa-link="' + item.crn + '-' + item.convictionNumber +'"">' +  item.name + '</a>', item.crn, 'govuk-body-s' )},
+            {
+                text: doubleCell('<a href="/pdu/' + pduCode +'/' + item.crn + '/convictions/' + item.convictionNumber +'/case-view" " class="govuk-link--no-visited-state" aria-label="Review case" data-qa-link="' + item.crn + '-' + item.convictionNumber +'"">' +  item.name + '</a>', item.crn, 'govuk-body-s' ),
+                attributes: { "data-sort-value": item.crn }
+            },
             { text: item.tier, attributes: { "data-sort-value": item.tierOrder } },
             { text: (item.sentenceDate | dateFormat), attributes: {
                 "data-sort-value": item.sentenceDate
             } },
             { text: item.handoverDate, attributes: { "data-sort-value": item.handoverDate } },
-            { text: doubleCell(item.primaryInitialAppointment,item.secondaryInitialAppointment, 'maw-secondary' )},
+            {
+                text: doubleCell(item.primaryInitialAppointment,item.secondaryInitialAppointment, 'maw-secondary' ),
+                attributes: { "data-sort-value": item.primaryInitialAppointment }
+            },
             { text: doubleCell(item.primaryStatus, item.secondaryStatus, 'govuk-body-s')}
         ] -%}
         {{ tableData.rows.push(tableRow) }}

--- a/server/views/pages/find-unallocated-cases.njk
+++ b/server/views/pages/find-unallocated-cases.njk
@@ -14,30 +14,45 @@
     head: [
         { text: 'Name / CRN',
             attributes: {
+                "col-number": "1",
                 "aria-sort": "none",
                 'data-persistent-id': 'find-unallocated-cases-name-crn'
             }
         },
         { text: 'Tier',
             attributes: {
+                "col-number": "2",
                 "aria-sort": "none",
                 'data-persistent-id': 'find-unallocated-cases-tier'
             }
         },
         { text: 'Sentence date',
             attributes: {
+                "col-number": "3",
                 "aria-sort": "none",
-                'data-persistent-id': 'find-unallocated-cases-sentence-date'
+                'data-persistent-id': 'find-unallocated-cases-sentence-date',
+                "date-pattern-for-sort": 'YY-MM-YYYY'
+            }
+        },
+        { text: 'COM Handover date',
+            attributes: {
+                "col-number": "4",
+                "aria-sort": "none",
+                'data-persistent-id': 'find-unallocated-cases-handover-date',
+                "date-pattern-for-sort": 'YY-MM-YYYY'
             }
         },
         { text: 'Initial appointment date',
             attributes: {
+                "col-number": "5",
                 "aria-sort": "none",
-                'data-persistent-id': 'find-unallocated-cases-appointment-date'
+                'data-persistent-id': 'find-unallocated-cases-appointment-date',
+                "date-pattern-for-sort": 'YY-MM-YYYY'
             }
         },
         { text: 'Probation status',
             attributes: {
+                "col-number": "6",
                 "aria-sort": "none",
                 'data-persistent-id': 'find-unallocated-cases-probation-status'
             }
@@ -59,6 +74,7 @@
             { text: (item.sentenceDate | dateFormat), attributes: {
                 "data-sort-value": item.sentenceDate
             } },
+            { text: item.handoverDate, attributes: { "data-sort-value": item.handoverDate } },
             {
                 colspan: "2",
                 text: 'This case is sitting in a different area, and the transfer process must be completed in NDelius before it can be allocated through the service. You can still review the case details.', attributes: { "data-sort-value": item.tierOrder }
@@ -72,6 +88,7 @@
             { text: (item.sentenceDate | dateFormat), attributes: {
                 "data-sort-value": item.sentenceDate
             } },
+            { text: item.handoverDate, attributes: { "data-sort-value": item.handoverDate } },
             { text: doubleCell(item.primaryInitialAppointment,item.secondaryInitialAppointment, 'maw-secondary' )},
             { text: doubleCell(item.primaryStatus, item.secondaryStatus, 'govuk-body-s')}
         ] -%}

--- a/server/views/pages/find-unallocated-cases.njk
+++ b/server/views/pages/find-unallocated-cases.njk
@@ -28,21 +28,21 @@
             attributes: {
                 "aria-sort": "none",
                 'data-persistent-id': 'find-unallocated-cases-sentence-date',
-                "date-pattern-for-sort": 'YY-MM-YYYY'
+                "data-type": 'DATE'
             }
         },
         { text: 'COM Handover date',
             attributes: {
                 "aria-sort": "none",
                 'data-persistent-id': 'find-unallocated-cases-handover-date',
-                "date-pattern-for-sort": 'YY-MM-YYYY'
+                "data-type": 'DATE'
             }
         },
         { text: 'Initial appointment date',
             attributes: {
                 "aria-sort": "none",
                 'data-persistent-id': 'find-unallocated-cases-appointment-date',
-                "date-pattern-for-sort": 'YY-MM-YYYY'
+                "data-type": 'DATE_ON_FIRST_LINE'
             }
         },
         { text: 'Probation status',


### PR DESCRIPTION
**This PR includes:**
- displaying the `handover-date` on the `Unallocated cases` page in the new `COM Handover Date` column
-  when we do not have a `handover-date`, displaying `N/A` on the `Unallocated cases page` in the new `COM Handover Date` column
- sorting for the new `COM Handover Date` column

**Details on sort:**
- I have done a big refactor to the sort as this was not fit for purpose for the table on the `Unallocated cases` page
- It was not fit for purpose because it does a `string sort` and in some of our columns (i.e. new `COM Handover Date` column and pre-existing `Initial appointment date` column) we convert the date to a formatted date string or `N/A` or `Unknown` in the case of appointment date)
- This means that `1 February 2024` would come before `1 January 2024` in an ascending search (as `F` comes before `J` in a string search)

**What is the situation in PROD right now?...**
- `Initial appointment date` sorting does not work as date is pre-formatted (e.g. `1 January 2024`)
- `Sentence Date` works fine as we do not pre-format the date. So at the point of sort the date value is in this format   `YYYY-MM-DD` (e.g. `2024-01-01`) and a `string sort` gets this right

**How does this PR fix this?...**
- It gives you the option of marking the table's column's header's metadata a new attribute called `data-type`
- When `data-type` is set to `DATE` then we convert the value to a date and then do a date sort
- if `data-type` is not set or is not set to `DATE` we do a string sort as always
- to use this data-type properly there are a lot of changes to our `mojSortableTable.js` script