### PR TITLE
:lipstick: WFP-2334: when C2C remove 4th bullet

### DIFF
--- a/integration_tests/integration/allocation-complete.spec.ts
+++ b/integration_tests/integration/allocation-complete.spec.ts
@@ -131,7 +131,7 @@ context('Allocate Complete', () => {
       .should('contain', 'no date found for the initial appointment, please check with your team')
   })
 
-  it('When a custody case, Initial appointment date not needed visible on page', () => {
+  it('When a custody case, Initial appointment not visible on page', () => {
     const instructionsConfirmPage = Page.verifyOnPage(InstructionsConfirmPage)
     instructionsConfirmPage.instructionsTextArea().type('Test')
     cy.task('stubAllocateOffenderManagerToCase')
@@ -140,8 +140,9 @@ context('Allocate Complete', () => {
     const allocationCompletePage = Page.verifyOnPage(AllocationCompletePage)
     allocationCompletePage
       .bulletedList()
-      .should('contain', 'no initial appointment needed (custody case)')
-      .and('contain', 'John Doe (john.doe@test.justice.gov.uk) has been notified')
+      .contains('John Doe (john.doe@test.justice.gov.uk) has been notified')
+      .contains('the initial appointment is scheduled for ')
+      .should('not.exist')
   })
 
   it('must keep instruction text after an errored allocation', () => {

--- a/server/views/pages/allocation-complete.njk
+++ b/server/views/pages/allocation-complete.njk
@@ -24,7 +24,6 @@
                 {{- ", and we've sent you a copy of your allocation instructions" if sendEmailCopyToAllocatingOfficer and not otherEmails | length}}
                 {{- ', and we have sent a copy of your allocation instructions to ' + ('you and ' if sendEmailCopyToAllocatingOfficer) + otherEmails | join(", ")  if otherEmails | length }}</li>
                 {% if data.type === 'CUSTODY' %}
-                    <li>no initial appointment needed (custody case)</li>
                 {% elseif data.initialAppointment.date %}
                     <li>the initial appointment is scheduled for <strong>{{ data.initialAppointment.date | dateFormat }}</strong></li>
                 {% else %}


### PR DESCRIPTION
This PR removes  the 4th bullet that mentions  'initial appointment' when a custody case

<img width="854" alt="Screenshot 2024-01-29 at 11 28 50" src="https://github.com/ministryofjustice/manage-a-workforce-ui/assets/51707463/44a91d4d-eead-4cb2-82d7-00dcedf5bfd8">
