### PR TITLE
WFP-2357 -  choose a probation practitioner page changes

### DIFF
--- a/integration_tests/integration/choose-practitioner.spec.ts
+++ b/integration_tests/integration/choose-practitioner.spec.ts
@@ -102,12 +102,20 @@ context('Choose Practitioner', () => {
     choosePractitionerPage.sectionBreak().should('exist')
   })
 
-  it('Sub heading is visible on page', () => {
+  it('Heading text is visible on page', () => {
     cy.task('stubGetCurrentlyManagedCaseForChoosePractitioner')
     cy.signIn()
     cy.visit('/pdu/PDU1/J678910/convictions/1/choose-practitioner')
     const choosePractitionerPage = Page.verifyOnPage(ChoosePractitionerPage)
-    choosePractitionerPage.subHeading().should('contain', 'Allocate to a probation practitioner')
+    choosePractitionerPage.headingText().should('have.text', 'Allocate to a probation practitioner')
+  })
+
+  it('Shows link to Edit my teams list', () => {
+    cy.task('stubGetCurrentlyManagedCaseForChoosePractitioner')
+    cy.signIn()
+    cy.visit('/pdu/PDU1/J678910/convictions/1/choose-practitioner')
+    const choosePractitionerPage = Page.verifyOnPage(ChoosePractitionerPage)
+    choosePractitionerPage.manageMyTeamsLink().should('equal', '/pdu/PDU1/select-teams')
   })
 
   it('Warning is visible on page if probation status is currently managed', () => {

--- a/integration_tests/pages/choosePractitioner.ts
+++ b/integration_tests/pages/choosePractitioner.ts
@@ -9,6 +9,8 @@ export default class ChoosePractitionerPage extends Page {
 
   warningIcon = (): PageElement => cy.get('.govuk-warning-text__icon')
 
+  captionText = (): PageElement => cy.get('.govuk-caption-l')
+
   tabs = (): PageElement => cy.get('[data-module="govuk-tabs"]')
 
   tab = (id: string): PageElement => cy.get(`[id="tab_${id}"]`)
@@ -28,4 +30,6 @@ export default class ChoosePractitionerPage extends Page {
   allocateCaseButton = (): PageElement => cy.get('form > div > button.govuk-button')
 
   clearSelectionButton = (): PageElement => cy.get(`.govuk-button--secondary`)
+
+  manageMyTeamsLink = (): PageElement => cy.get('[data-qa-link="select-teams"]').invoke('attr', 'href')
 }

--- a/server/views/components/pop/template.njk
+++ b/server/views/components/pop/template.njk
@@ -1,8 +1,15 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">{{ params.name }}
-            <span class="govuk-caption-xl">Tier: {{ params.tier }}</span>
-            <span class="govuk-caption-xl">CRN: {{ params.crn }}</span>
-        </h1>
+        {% if 'lg' == params.popSize -%}
+            <h1 class="govuk-heading-l govuk-!-margin-bottom-2">{{ params.name }}
+                <span class="govuk-caption-l">Tier: {{ params.tier }}</span>
+                <span class="govuk-caption-l">CRN: {{ params.crn }}</span>
+            </h1>
+        {% else %}
+            <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">{{ params.name }}
+                <span class="govuk-caption-xl">Tier: {{ params.tier }}</span>
+                <span class="govuk-caption-xl">CRN: {{ params.crn }}</span>
+            </h1>
+        {%- endif %}
     </div>
 </div>

--- a/server/views/components/pop/template.njk
+++ b/server/views/components/pop/template.njk
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         {% if 'lg' == params.popSize -%}
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-2">{{ params.name }}
+            <h1 class="govuk-heading-l govuk-!-margin-bottom-10">{{ params.name }}
                 <span class="govuk-caption-l">Tier: {{ params.tier }}</span>
                 <span class="govuk-caption-l">CRN: {{ params.crn }}</span>
             </h1>

--- a/server/views/pages/choose-practitioner.njk
+++ b/server/views/pages/choose-practitioner.njk
@@ -185,11 +185,10 @@
     </div>
     {% endif %}
 
-    {{ pop({name: name, crn: crn, tier: tier}) }}
-
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">Allocate to a probation practitioner</h1>
+    <a class="govuk-body-s govuk-link--no-visited-state" data-qa-link="select-teams" href="/pdu/{{pduCode}}/select-teams">Edit my teams list</a>
     <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-
-    <h2 class="govuk-heading-l">Allocate to a probation practitioner</h2>
+    {{ pop({name: name, crn: crn, tier: tier, popSize: 'lg' }) }}
 
     {% if (probationStatus == 'Currently managed' and offenderManagerDetails) or probationStatus == 'Previously managed' %}
         <div class="govuk-warning-text">


### PR DESCRIPTION
In a nutshell, this PR makes 2 changes to this page:
1. Swaps the headers around
2. Add an `Edit teams` link which redirect to that page.

How does it look now...

<img width="1728" alt="02__after" src="https://github.com/ministryofjustice/manage-a-workforce-ui/assets/148795810/80a56f49-d900-4c5e-ac14-97a0e614df45">
