### PR TITLE
WFP-2363 increase timeout for allocations service

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -57,9 +57,9 @@ export default {
     allocationsService: {
       url: get('ALLOCATIONS_SERVICE_URL', 'http://127.0.0.1:9091', requiredInProduction),
       timeout: {
-        response: 3000,
+        response: 10000,
       },
-      agent: new AgentConfig(3000),
+      agent: new AgentConfig(10000),
       retries: 2,
     },
     workloadService: {


### PR DESCRIPTION
Increasing the timeout for the allocations service to 10 seconds (up from 3 seconds) as we noticed we were experiencing ui -> allocations 500 timeouts. Whilst this does not solve the root cause of the WFP-2362 ticket, it is a small incremental improvement which should decrease the number of 500 timeout errors the service experiences