### PR TITLE
:sparkles: WFP-2222: grab pageUrl to use as survey monkey custom vari…

### DIFF
--- a/server/controllers/allocateCasesController.ts
+++ b/server/controllers/allocateCasesController.ts
@@ -43,6 +43,7 @@ export default class AllocateCasesController {
     }
     res.render('pages/allocate-cases-by-team', {
       title: 'Allocate cases by team | Manage a workforce',
+      pageUrl: `${req.headers.host}${req.url}`,
       teams: caseInformationByTeam,
       pduCode,
       pduName: probationDeliveryUnitDetails.name,

--- a/server/controllers/allocationHistoryController.ts
+++ b/server/controllers/allocationHistoryController.ts
@@ -33,6 +33,7 @@ export default class AllocationHistoryController {
       isFindUnalllocatedCasesPage: false,
       isCaseAllocationHistoryPage: true,
       title: 'Cases allocated in last 30 days | Manage a workforce',
+      pageUrl: `${req.headers.host}${req.url}`,
       pduCode,
       pduDetails,
       casesLength: 0,

--- a/server/controllers/allocationsController.ts
+++ b/server/controllers/allocationsController.ts
@@ -46,6 +46,7 @@ export default class AllocationsController {
       name: response.name,
       convictionNumber: response.convictionNumber,
       title: `${response.name} | Summary | Manage a workforce`,
+      pageUrl: `${req.headers.host}${req.url}`,
       pduCode,
       outOfAreaTransfer: response.outOfAreaTransfer,
     })
@@ -94,6 +95,7 @@ export default class AllocationsController {
       totalPreviousCount,
       convictionNumber: probationRecord.convictionNumber,
       title: `${probationRecord.name} | Probation record | Manage a workforce`,
+      pageUrl: `${req.headers.host}${req.url}`,
       pduCode,
       outOfAreaTransfer: unallocatedCase.outOfAreaTransfer,
     })
@@ -106,6 +108,7 @@ export default class AllocationsController {
     ])
     res.render('pages/risk', {
       title: `${risk.name} | Risk | Manage a workforce`,
+      pageUrl: `${_.headers.host}${_.url}`,
       data: risk,
       crn: risk.crn,
       tier: risk.tier,
@@ -125,6 +128,7 @@ export default class AllocationsController {
     const documentRows = documents.map(document => new DocumentRow(document))
     res.render('pages/documents', {
       title: `${caseOverview.name} | Documents | Manage a workforce`,
+      pageUrl: `${_.headers.host}${_.url}`,
       crn: caseOverview.crn,
       tier: caseOverview.tier,
       name: caseOverview.name,
@@ -230,6 +234,7 @@ export default class AllocationsController {
     )
     res.render('pages/decision-evidence', {
       title: `${response.name.combinedName} | Explain your decision | Manage a workforce`,
+      pageUrl: `${req.headers.host}${req.url}`,
       data: response,
       name: response.name.combinedName,
       crn,
@@ -299,6 +304,7 @@ export default class AllocationsController {
     )
     res.render('pages/confirm-instructions', {
       title: `${response.name.combinedName} | Review allocation instructions | Manage a workforce`,
+      pageUrl: `${req.headers.host}${req.url}`,
       data: response,
       name: response.name.combinedName,
       crn: response.crn,

--- a/server/controllers/findUnallocatedCasesController.ts
+++ b/server/controllers/findUnallocatedCasesController.ts
@@ -84,6 +84,7 @@ export default class FindUnallocatedCasesController {
       isCaseAllocationHistoryPage: false,
       pduDetails,
       title: 'Unallocated cases | Manage a workforce',
+      pageUrl: `${req.headers.host}${req.url}`,
       errors: req.flash('errors') || [],
       dropDownSelectionData: JSON.stringify(allEstate),
       pduOptions,

--- a/server/controllers/probationEstateController.ts
+++ b/server/controllers/probationEstateController.ts
@@ -18,6 +18,7 @@ export default class ProbationEstateController {
     )
     res.render('pages/select-teams', {
       title: `Select your teams | Manage a workforce`,
+      pageUrl: `${req.headers.host}${req.url}`,
       data: response.teams.sort((a, b) => a.name.localeCompare(b.name)),
       error,
       pduName: response.name,

--- a/server/controllers/technicalUpdatesController.ts
+++ b/server/controllers/technicalUpdatesController.ts
@@ -7,6 +7,7 @@ export default class TechnicalUpdatesController {
   async getTechnicalUpdates(req: Request, res: Response): Promise<void> {
     return res.render('pages/technical-updates', {
       title: `New features | Manage a workforce`,
+      pageUrl: `${req.headers.host}${req.url}`,
       referrer: req.get('Referrer'),
       technicalUpdates: this.technicalUpdatesService.getTechnicalUpdates(),
     })

--- a/server/controllers/workloadController.ts
+++ b/server/controllers/workloadController.ts
@@ -50,6 +50,7 @@ export default class WorkloadController {
 
     return res.render('pages/allocation-complete', {
       title: `${allocationCompleteDetails.name.combinedName} | Case allocated | Manage a workforce`,
+      pageUrl: `${req.headers.host}${req.url}`,
       data: allocationCompleteDetails,
       crn,
       convictionNumber,

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -155,6 +155,10 @@
                 {
                     href: "/privacy-notice",
                     text: "Privacy"
+                },
+                {
+                    href: "https://eu.surveymonkey.com/r/LXM9XPZ?url="+ pageUrl,
+                    text: "Survey"
                 }
             ]
 %}


### PR DESCRIPTION
…able

So this is a PR just to show what I did to grab the url and add into the survey monkey link so we can get the url of the page where the user has come from and see if they think the page is useful or not.

This ticket https://dsdmoj.atlassian.net/jira/software/c/projects/WFP/boards/601?selectedIssue=WFP-2222 has more information about how it works with survey monkey.

When picking up the piece of work we'd need to add a banner that links to the survey but in this PR I've just added it into the footer as I just wanted to see if we'd get the results coming through the survey.