### PR TITLE
PI-2705 Add MOJ Cloud Platform to the IP allow list group for dev

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -22,17 +22,9 @@ generic-service:
     enabled: true
 
   allowlist:
-    unilink-aovpn1: 194.75.210.216/29
-    unilink-aovpn3: 78.33.10.50/31
-    unilink-aovpn4: 78.33.10.52/30
-    unilink-aovpn5: 78.33.10.56/30
-    unilink-aovpn6: 78.33.10.60/32
-    unilink-aovpn7: 78.33.32.99/32
-    unilink-aovpn8: 78.33.32.100/30
-    unilink-aovpn9: 78.33.32.104/30
-    unilink-aovpn10: 78.33.32.108/32
     groups:
       - digital_staff_and_mojo
+      - moj_cloud_platform
       - prisons
       - unilink_staff
 


### PR DESCRIPTION
This is required for the Probation Integration end-to-end tests to access the MAW front-end.

I've also removed the Unilink VPN ranges, as the latest ranges are available from the `unilink_staff` group.