### PR TITLE
Pipeline changes to allow e2e tests to run as part of the main MAW-UI Pipeline

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -32,12 +32,6 @@ jobs:
           npm install
           npm run build
           npm run start-external-test &
-      - name: Install e2e dependencies
-        run: npm install
-        working-directory: e2e-tests
-      - name: Run Docker Compose to start dependencies
-        run: docker compose up -d
-        working-directory: e2e-tests
       - name: Wait for maw-ui application to be ready
         run: |
           for i in {1..60}; do
@@ -45,6 +39,13 @@ jobs:
             sleep 5
           done
           echo "App failed to start" && exit 1
+      - name: Install e2e dependencies
+        run: npm install
+        working-directory: e2e-tests
+      - name: Run Docker Compose to start dependencies
+        run: docker compose up -d
+        working-directory: e2e-tests
+
       - name: Run e2e tests
         run: npm run test:all
         working-directory: e2e-tests

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout e2e tests repo
         uses: actions/checkout@v5
         with:
-          repository: ministryofjustice/manage-a-workforce-ui-e2e-tests
+          repository: ministryofjustice/hmpps-manage-a-workforce-ui-e2e-tests
           path: e2e-tests
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: main

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -22,6 +22,7 @@ jobs:
           repository: ministryofjustice/manage-a-workforce-ui-e2e-tests
           path: e2e-tests
           token: ${{ secrets.GITHUB_TOKEN }}
+          ref: main
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -51,4 +52,3 @@ jobs:
       - name: Stop Docker Compose
         if: always()
         run: docker-compose down
-        working-directory: e2e-tests

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -47,9 +47,10 @@ jobs:
         run: docker compose up -d
         working-directory: e2e-tests
 
-      - name: Run e2e tests
-        run: npm run test:all
-        working-directory: e2e-tests
+        #uncomment when you have tests to run
+      - #name: Run e2e tests
+        #run: npm run test:all
+        #working-directory: e2e-tests
       - name: Stop Docker Compose
         if: always()
         run: docker compose down

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Wait for maw-ui application to be ready
         run: |
           for i in {1..60}; do
-            if curl -sSf http://localhost:3000/health; then exit 0; fi
+            if curl -sSf http://localhost:3007/health; then exit 0; fi
             sleep 5
           done
           echo "App failed to start" && exit 1

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -1,0 +1,39 @@
+name: E2E Tests
+on:
+  workflow_call:
+    inputs:
+      node_version_file:
+        description: 'Passed to setup-node action to specify where to source the version of node from'
+        required: false
+        type: string
+        default: '.nvmrc'
+permissions:
+  contents: read
+jobs:
+  e2e-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main repo
+        uses: actions/checkout@v5
+
+      - name: Checkout e2e tests repo
+        uses: actions/checkout@v5
+        with:
+          repository: ministryofjustice/manage-a-workforce-ui-e2e-tests
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ${{ inputs.node_version_file }}
+      - name: Run Docker Compose to start dependencies
+        run: |
+          cd e2e-tests
+          docker-compose up -d
+      - name: Install e2e dependencies
+        run: |
+          cd e2e-tests
+          npm ci
+      - name: Run e2e tests
+        run: |
+          cd e2e-tests
+          npm test # or npx cypress run, etc.

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -47,10 +47,10 @@ jobs:
         run: docker compose up -d
         working-directory: e2e-tests
 
-        #uncomment when you have tests to run
-      - #name: Run e2e tests
-        #run: npm run test:all
-        #working-directory: e2e-tests
+        # uncomment when you have tests to run
+        # - name: Run e2e tests
+        # run: npm run test:all
+        # working-directory: e2e-tests
       - name: Stop Docker Compose
         if: always()
         run: docker compose down

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -20,20 +20,35 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: ministryofjustice/manage-a-workforce-ui-e2e-tests
+          path: e2e-tests
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version-file: ${{ inputs.node_version_file }}
-      - name: Run Docker Compose to start dependencies
+      - name: Start maw-ui application
         run: |
-          cd e2e-tests
-          docker-compose up -d
-      - name: Install e2e dependencies
-        run: |
-          cd e2e-tests
+          cd ..
           npm ci
-      - name: Run e2e tests
+          npm run build
+          npm run start-external-test &
+      - name: Install e2e dependencies
+        run: npm ci
+        working-directory: e2e-tests
+      - name: Run Docker Compose to start dependencies
+        run: docker-compose up -d
+        working-directory: e2e-tests
+      - name: Wait for maw-ui application to be ready
         run: |
-          cd e2e-tests
-          npm test # or npx cypress run, etc.
+          for i in {1..60}; do
+            if curl -sSf http://localhost:3000/health; then exit 0; fi
+            sleep 5
+          done
+          echo "App failed to start" && exit 1
+      - name: Run e2e tests
+        run: npm run test:all
+        working-directory: e2e-tests
+      - name: Stop Docker Compose
+        if: always()
+        run: docker-compose down
+        working-directory: e2e-tests

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -29,7 +29,6 @@ jobs:
           node-version-file: ${{ inputs.node_version_file }}
       - name: Start maw-ui application
         run: |
-          cd ..
           npm install
           npm run build
           npm run start-external-test &
@@ -37,7 +36,7 @@ jobs:
         run: npm install
         working-directory: e2e-tests
       - name: Run Docker Compose to start dependencies
-        run: docker-compose up -d
+        run: docker compose up -d
         working-directory: e2e-tests
       - name: Wait for maw-ui application to be ready
         run: |
@@ -51,4 +50,4 @@ jobs:
         working-directory: e2e-tests
       - name: Stop Docker Compose
         if: always()
-        run: docker-compose down
+        run: docker compose down

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -30,11 +30,11 @@ jobs:
       - name: Start maw-ui application
         run: |
           cd ..
-          npm ci
+          npm install
           npm run build
           npm run start-external-test &
       - name: Install e2e dependencies
-        run: npm ci
+        run: npm install
         working-directory: e2e-tests
       - name: Run Docker Compose to start dependencies
         run: docker-compose up -d

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -27,11 +27,15 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: ${{ inputs.node_version_file }}
+      - name: Install e2e dependencies
+        run: npm install
+        working-directory: e2e-tests
       - name: Start maw-ui application
         run: |
           npm install
           npm run build
           npm run start-external-test &
+        working-directory: .
       - name: Wait for maw-ui application to be ready
         run: |
           for i in {1..60}; do
@@ -39,9 +43,6 @@ jobs:
             sleep 5
           done
           echo "App failed to start" && exit 1
-      - name: Install e2e dependencies
-        run: npm install
-        working-directory: e2e-tests
       - name: Run Docker Compose to start dependencies
         run: docker compose up -d
         working-directory: e2e-tests

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -2,13 +2,13 @@ name: Pipeline [test -> build -> deploy]
 on:
   push:
     branches:
-      - '**'
+      - "**"
   workflow_dispatch:
     inputs:
       additional_docker_tag:
         description: Additional docker tag that can be used to specify stable or testing tags
         required: false
-        default: ''
+        default: ""
         type: string
       push:
         description: Push docker image to registry flag
@@ -39,7 +39,7 @@ jobs:
   helm_lint:
     strategy:
       matrix:
-        environments: ['dev', 'preprod', 'prod']
+        environments: ["dev", "preprod", "prod"]
     name: helm lint
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/test_helm_lint.yml@v2 # WORKFLOW_VERSION
     secrets: inherit
@@ -53,8 +53,8 @@ jobs:
       - node_integration_tests
       - node_unit_tests
     with:
-      docker_registry: 'ghcr.io'
-      registry_org: 'ministryofjustice'
+      docker_registry: "ghcr.io"
+      registry_org: "ministryofjustice"
       additional_docker_tag: ${{ inputs.additional_docker_tag }}
       push: ${{ inputs.push || true }}
       docker_multiplatform: false
@@ -66,18 +66,20 @@ jobs:
       - build
       - helm_lint
     secrets: inherit
+
   deploy_dev:
     name: Deploy to the dev environment
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/epic')
+    if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/epic')) && (needs.end-to-end-tests.result == 'success' || needs.end-to-end-tests.result == 'skipped')
     needs:
       - build
       - helm_lint
+      - end-to-end-tests
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@v2 # WORKFLOW_VERSION
     secrets: inherit
     with:
-      environment: 'dev'
-      app_version: '${{ needs.build.outputs.app_version }}'
-      helm_timeout: '5m'
+      environment: "dev"
+      app_version: "${{ needs.build.outputs.app_version }}"
+      helm_timeout: "5m"
   deploy_preprod:
     name: Deploy to the preprod environment
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/epic')
@@ -88,9 +90,9 @@ jobs:
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@v2 # WORKFLOW_VERSION
     secrets: inherit
     with:
-      environment: 'preprod'
-      app_version: '${{ needs.build.outputs.app_version }}'
-      helm_timeout: '5m'
+      environment: "preprod"
+      app_version: "${{ needs.build.outputs.app_version }}"
+      helm_timeout: "5m"
   deploy_prod:
     name: Deploy to the prod environment
     if: github.ref == 'refs/heads/main'
@@ -101,6 +103,6 @@ jobs:
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@v2 # WORKFLOW_VERSION
     secrets: inherit
     with:
-      environment: 'prod'
-      app_version: '${{ needs.build.outputs.app_version }}'
-      helm_timeout: '5m'
+      environment: "prod"
+      app_version: "${{ needs.build.outputs.app_version }}"
+      helm_timeout: "5m"

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -70,7 +70,6 @@ jobs:
     name: Deploy to the dev environment
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/epic')
     needs:
-      - node_unit_tests
       - build
       - helm_lint
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@v2 # WORKFLOW_VERSION

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -58,10 +58,19 @@ jobs:
       additional_docker_tag: ${{ inputs.additional_docker_tag }}
       push: ${{ inputs.push || true }}
       docker_multiplatform: false
+  end-to-end-tests:
+    name: end to end tests
+    if: startsWith(github.ref, 'refs/heads/epic-e2e')
+    uses: ./.github/workflows/e2e_tests.yml # LOCAL_VERSION
+    needs:
+      - build
+      - helm_lint
+    secrets: inherit
   deploy_dev:
     name: Deploy to the dev environment
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/epic')
     needs:
+      - node_unit_tests
       - build
       - helm_lint
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@v2 # WORKFLOW_VERSION


### PR DESCRIPTION
Changes to pipeline.

This is currently not blocking pipeline, and the e2e tests will only run for an EPIC branch starting with the name of 'epic-e2e'

It is currently a failing step (due to the wiremock mappings) - however when the tests start passing in the e2e repo, I would expect this one also to pass