### PR TITLE
Wfp 3651 pluralise workload details

### DIFF
--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -73,6 +73,10 @@ export default async function nunjucksSetup(
     return Array.isArray(str)
   })
 
+  njkEnv.addFilter('pluralise', (count: number, singular: string, plural?: string) => {
+    return count === 1 ? singular : plural || `${singular}s`
+  })
+
   njkEnv.addGlobal('workloadMeasurementUrl', config.nav.workloadMeasurement.url)
   njkEnv.addGlobal('tagManagerContainerId', config.analytics.tagManagerContainerId.trim())
   njkEnv.addGlobal('lastTechnicalUpdate', services.technicalUpdatesService.getLatestTechnicalUpdateHeading())

--- a/server/views/components/practitioner-list/template.njk
+++ b/server/views/components/practitioner-list/template.njk
@@ -56,8 +56,10 @@
 {% for offenderManager in params.offenderManagers %}
     {% if offenderManager.code !== params.currentOffenderManager.code %}
         {%- set workloadDetailsHtml -%}
-        {{ 
+        {{
             workloadDetails({
+                name: offenderManager.name.combinedName,
+                id: offenderManager.code,
                 tierCaseTotals: {
                     a: offenderManager.tierCaseTotals.a,
                     b: offenderManager.tierCaseTotals.b,
@@ -68,20 +70,20 @@
                     g: offenderManager.tierCaseTotals.cs
                 },
                 communityCases: offenderManager.communityCases,
-                licenseCases: offenderManager.licenseCases,
-                custodyCases: offenderManager.custodyCases,
-                activeCases: offenderManager.activeCases,
-                contactSuspendedCases: offenderManager.contactSuspendedCases,
-                custodyReleasesInNext7Days: offenderManager.custodyReleasesInNext7Days,
-                paroleReportsInNext28Days: offenderManager.paroleReportsInNext28Days,
-                otherReportsInNext14Days: offenderManager.otherReportsInNext14Days
-            }) 
+                licenseCases: 1,
+                custodyCases: 3,
+                activeCases: 3,
+                contactSuspendedCases: 1,
+                custodyReleasesInNext7Days: 0,
+                paroleReportsInNext28Days: 4,
+                otherReportsInNext14Days: 1
+            })
         }}
 
         {%- endset -%}
 
         {%- set tableRow = [
-            { 
+            {
                 html: ('<div class="govuk-radios govuk-radios--small"><div class="govuk-radios__item"><input class="govuk-radios__input" id="allocated-officer-' + offenderManager.code + '" name="allocatedOfficer" type="radio" value="' + offenderManager.selectionCode + '"' + (' checked' if params.teamAndStaffCode == offenderManager.selectionCode) + '><label class="govuk-label govuk-radios__label" for="allocated-officer-' + offenderManager.code + '"><span tabindex="-1" class="govuk-visually-hidden">Select ' + offenderManager.name.combinedName + ' to allocate to</span></label></div></div>' + workloadDetailsHtml)
                 if offenderManager.email and true != offenderManager.laoCase
             },

--- a/server/views/components/practitioner-list/template.njk
+++ b/server/views/components/practitioner-list/template.njk
@@ -59,7 +59,6 @@
         {{
             workloadDetails({
                 name: offenderManager.name.combinedName,
-                id: offenderManager.code,
                 tierCaseTotals: {
                     a: offenderManager.tierCaseTotals.a,
                     b: offenderManager.tierCaseTotals.b,

--- a/server/views/components/practitioner-list/template.njk
+++ b/server/views/components/practitioner-list/template.njk
@@ -70,13 +70,13 @@
                     g: offenderManager.tierCaseTotals.cs
                 },
                 communityCases: offenderManager.communityCases,
-                licenseCases: 1,
-                custodyCases: 3,
-                activeCases: 3,
-                contactSuspendedCases: 1,
-                custodyReleasesInNext7Days: 0,
-                paroleReportsInNext28Days: 4,
-                otherReportsInNext14Days: 1
+                licenseCases: offenderManager.licenseCases,
+                custodyCases: offenderManager.custodyCases,
+                activeCases: offenderManager.activeCases,
+                contactSuspendedCases: offenderManager.contactSuspendedCases,
+                custodyReleasesInNext7Days: offenderManager.custodyReleasesInNext7Days,
+                paroleReportsInNext28Days: offenderManager.paroleReportsInNext28Days,
+                otherReportsInNext14Days: offenderManager.otherReportsInNext14Days
             })
         }}
 

--- a/server/views/components/workloadDetails/template.njk
+++ b/server/views/components/workloadDetails/template.njk
@@ -1,4 +1,8 @@
-<details class="govuk-details workload-details">
+<h3 id="workload-heading-{{ params.id }}" class="govuk-visually-hidden">
+{{ params.name }}’s workload
+</h3>
+
+<details aria-labelledby="workload-heading-{{ params.id }}" class="govuk-details workload-details">
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">
                     View workload
@@ -7,7 +11,7 @@
   <div class="govuk-details__text">
 
     <div class="workload-section">
-      <h3 class="govuk-heading-s">Case mix by tier</h3>
+      <h4 class="govuk-heading-s">Case mix by tier</h4>
 
       <div class="workload-inline">
         <span>
@@ -28,7 +32,7 @@
     </div>
 
     <div class="workload-section">
-      <h3 class="govuk-heading-s">Case mix by type</h3>
+      <h4 class="govuk-heading-s">Case mix by type</h4>
 
       <div class="workload-inline">
         <span>
@@ -41,19 +45,19 @@
     </div>
 
     <div class="workload-section">
-      <h3 class="govuk-heading-s">Caseload volume and reports due</h3>
+      <h4 class="govuk-heading-s">Caseload volume and reports due</h4>
 
       <ul class="govuk-list">
         <li>
-          <strong>{{ params.activeCases }}</strong> active cases</li>
+          <strong>{{ params.activeCases }}</strong> {{ params.activeCases | pluralise("active case") }}</li>
         <li>
-          <strong>{{ params.contactSuspendedCases }}</strong> contact suspended cases</li>
+          <strong>{{ params.contactSuspendedCases }}</strong> {{ params.contactSuspendedCases | pluralise("contact suspended case") }}</li>
         <li>
-          <strong>{{ params.custodyReleasesInNext7Days }}</strong> custody releases in next 7 days</li>
+          <strong>{{ params.custodyReleasesInNext7Days }}</strong> {{ params.custodyReleasesInNext7Days | pluralise("custody release") }} in next 7 days</li>
         <li>
-          <strong>{{ params.paroleReportsInNext28Days }}</strong> parole report in next 28 days</li>
+          <strong>{{ params.paroleReportsInNext28Days }}</strong> {{ params.paroleReportsInNext28Days | pluralise("parole report") }} in next 28 days</li>
         <li>
-          <strong>{{ params.otherReportsInNext14Days }}</strong> other reports in next 14 days</li>
+          <strong>{{ params.otherReportsInNext14Days }}</strong> {{ params.otherReportsInNext14Days | pluralise("other report") }} in next 14 days</li>
       </ul>
     </div>
 

--- a/server/views/components/workloadDetails/template.njk
+++ b/server/views/components/workloadDetails/template.njk
@@ -1,8 +1,8 @@
-<h3 id="workload-heading-{{ params.id }}" class="govuk-visually-hidden">
+<h3 class="govuk-visually-hidden">
 {{ params.name }}’s workload
 </h3>
 
-<details aria-labelledby="workload-heading-{{ params.id }}" class="govuk-details workload-details">
+<details class="govuk-details workload-details">
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">
                     View workload


### PR DESCRIPTION
For this PR I have improved the workload details component to meet the acceptance criteria. I have done:

- added a nunjucks filter to pluralise content if more than one or zero

<img width="1354" height="680" alt="Sanactha Foact" src="https://github.com/user-attachments/assets/3090198b-0762-4d7a-a0ce-fce452a587a8" />

- added a hidden H3 for screen readers at the top of the component titled ‘[Name]’s workload’ 
<img width="1208" height="742" alt="image" src="https://github.com/user-attachments/assets/a4831f71-7d16-405c-8e51-067f824eeec5" />

- corrected heading mark up to improve accessibility
