### PR TITLE
Wfp 3666 fix pds header

### DIFF
--- a/assets/js/govukFrontendInit.js
+++ b/assets/js/govukFrontendInit.js
@@ -1,5 +1,6 @@
-import { initAll } from '/assets/govuk/govuk-frontend.min.js'
-initAll()
+if (typeof window.GOVUKFrontend !== 'undefined' && typeof window.GOVUKFrontend.initAll === 'function') {
+  window.GOVUKFrontend.initAll()
+}
 
 document.querySelectorAll('a[data-back]').forEach(elem => {
   elem.addEventListener('click', () => window.history.back())

--- a/assets/js/mojFrontendInit.js
+++ b/assets/js/mojFrontendInit.js
@@ -1,7 +1,24 @@
-window.MOJFrontend.initAll()
+// Initialise MOJ Frontend components (except SortableTable which is handled in mojSortableTable.js)
+// We need to manually initialise components since we override SortableTable initialisation
+if (typeof window.MOJFrontend !== 'undefined' && typeof window.MOJFrontend.initAll === 'function') {
+  window.MOJFrontend.initAll()
+}
+
+// Initialise natural sortable tables if they exist
 var $naturalSortableTables = document.querySelectorAll('[data-module="moj-natural-sortable-table"]')
-MOJFrontend.nodeListForEach($naturalSortableTables, function ($table) {
-  new MOJFrontend.NaturalSortableTable({
-    table: $table,
-  })
-})
+if (typeof MOJFrontend !== 'undefined' && typeof MOJFrontend.NaturalSortableTable === 'function') {
+  if (typeof MOJFrontend.nodeListForEach === 'function') {
+    MOJFrontend.nodeListForEach($naturalSortableTables, function ($table) {
+      new MOJFrontend.NaturalSortableTable({
+        table: $table,
+      })
+    })
+  } else {
+    // Fallback for versions that don't have nodeListForEach
+    Array.from($naturalSortableTables).forEach(function ($table) {
+      new MOJFrontend.NaturalSortableTable({
+        table: $table,
+      })
+    })
+  }
+}

--- a/assets/js/mojSortableTable.js
+++ b/assets/js/mojSortableTable.js
@@ -288,7 +288,7 @@ function getClickedColumn(columnIndex) {
   const currentTableDTO = PersistentSortOrder.fetchCurrentTablePersistentIdDTO()
   if (currentTableDTO) {
     const matchingColumns = currentTableDTO.currentTableColumns.filter(
-      column => column.columnIndex.toString() === columnIndex,
+      column => column.columnIndex.toString() === columnIndex.toString(),
     )
     if (matchingColumns.length > 0) {
       clickedColumn = matchingColumns[0]

--- a/assets/js/mojSortableTable.js
+++ b/assets/js/mojSortableTable.js
@@ -212,134 +212,139 @@ class PersistentSortOrder {
   }
 }
 
-$(() => {
-  const tables = document.getElementsByTagName('table')
-  if (tables.length === 0) {
-    console.warn('No tables found in document. Not setting up sortable table.')
+function sortStringAsc(valueA, valueB) {
+  if (valueA < valueB) {
+    return -1
+  }
+  if (valueA > valueB) {
+    return 1
+  }
+  return 0
+}
+
+function sortStringDesc(valueA, valueB) {
+  if (valueB < valueA) {
+    return -1
+  }
+  if (valueB > valueA) {
+    return 1
+  }
+  return 0
+}
+
+function sortDateAsc(date1String, date2String) {
+  const { date1, date2 } = convertDates(date1String, date2String)
+  if (date1 < date2) {
+    return -1
+  } else if (date1 > date2) {
+    return 1
+  }
+  return 0
+}
+
+function sortDateDesc(date1String, date2String) {
+  const { date1, date2 } = convertDates(date1String, date2String)
+  if (date2 < date1) {
+    return -1
+  }
+  if (date2 > date1) {
+    return 1
+  }
+  return 0
+}
+
+function valueIsSet(value) {
+  return value !== undefined && value !== '' && value !== 'N/A'
+}
+
+function convertDates(date1String, date2String) {
+  return {
+    date1: convertDate(date1String),
+    date2: convertDate(date2String),
+  }
+}
+
+function convertDate(dateString) {
+  const farInTheFutureDate = Date.parse('3000-01-01')
+  if (valueIsSet(dateString)) {
+    let convertedDate = Date.parse(dateString)
+    if (isNaN(convertedDate)) {
+      convertedDate = farInTheFutureDate
+    }
+    return convertedDate
+  }
+  return farInTheFutureDate
+}
+
+function isSortDataTypeADate(dataType) {
+  return dataType && (dataType === 'DATE' || dataType === 'DATE_ON_FIRST_LINE')
+}
+
+function getClickedColumn(columnIndex) {
+  let clickedColumn = {
+    columnIndex: columnIndex,
+    columnDataType: 'string',
+  }
+  const currentTableDTO = PersistentSortOrder.fetchCurrentTablePersistentIdDTO()
+  if (currentTableDTO) {
+    const matchingColumns = currentTableDTO.currentTableColumns.filter(
+      column => column.columnIndex.toString() === columnIndex,
+    )
+    if (matchingColumns.length > 0) {
+      clickedColumn = matchingColumns[0]
+    }
+  }
+  return clickedColumn
+}
+
+function sortRows($rows, columnNumber, sortDirection, getCellValueFn) {
+  const clickedColumn = getClickedColumn(columnNumber)
+  const sortDataTypeIsDate = isSortDataTypeADate(clickedColumn.columnDataType)
+
+  return $rows.sort(($rowA, $rowB) => {
+    const $tdA = $rowA.querySelectorAll('td, th')[columnNumber]
+    const $tdB = $rowB.querySelectorAll('td, th')[columnNumber]
+
+    if (!$tdA || !$tdB || !($tdA instanceof HTMLElement) || !($tdB instanceof HTMLElement)) {
+      return 0
+    }
+
+    const valueA = getCellValueFn($tdA)
+    const valueB = getCellValueFn($tdB)
+
+    if (sortDirection === 'ascending') {
+      if (sortDataTypeIsDate) {
+        return sortDateAsc(valueA, valueB)
+      } else {
+        return sortStringAsc(valueA, valueB)
+      }
+    } else {
+      if (sortDataTypeIsDate) {
+        return sortDateDesc(valueA, valueB)
+      } else {
+        return sortStringDesc(valueA, valueB)
+      }
+    }
+  })
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const tables = document.querySelectorAll('table[data-module="moj-sortable-table"]')
+  if (typeof MOJFrontend === 'undefined' || typeof MOJFrontend.SortableTable !== 'function') {
+    console.warn('MOJFrontend.SortableTable is unavailable; sortable tables were not initialised.')
     return
   }
 
-  function SortableTable(tableElement) {
-    // Calls the SortableTable constructor with `this` as its context
-    MOJFrontend.SortableTable.call(this, tableElement)
-  }
-  SortableTable.prototype = Object.create(MOJFrontend.SortableTable.prototype)
-
-  function sortStringAsc(valueA, valueB) {
-    if (valueA < valueB) {
-      return -1
-    }
-    if (valueA > valueB) {
-      return 1
-    }
-    return 0
+  // Keep custom date/string sorting behaviour used by tables.
+  MOJFrontend.SortableTable.prototype.sort = function ($rows, columnNumber, sortDirection) {
+    return sortRows($rows, columnNumber, sortDirection, this.getCellValue.bind(this))
   }
 
-  function sortStringDesc(valueA, valueB) {
-    if (valueB < valueA) {
-      return -1
+  tables.forEach(table => {
+    // `initAll()` may already have initialised this table.
+    if (!table.hasAttribute('data-moj-sortable-table-init')) {
+      new MOJFrontend.SortableTable(table)
     }
-    if (valueB > valueA) {
-      return 1
-    }
-    return 0
-  }
-
-  function sortDateAsc(date1String, date2String) {
-    const { date1, date2 } = convertDates(date1String, date2String)
-    if (date1 < date2) {
-      return -1
-    } else if (date1 > date2) {
-      return 1
-    }
-    return 0
-  }
-
-  function sortDateDesc(date1String, date2String) {
-    const { date1, date2 } = convertDates(date1String, date2String)
-    if (date2 < date1) {
-      return -1
-    }
-    if (date2 > date1) {
-      return 1
-    }
-    return 0
-  }
-
-  function valueIsSet(value) {
-    return value !== undefined && value !== '' && value !== 'N/A'
-  }
-
-  function convertDates(date1String, date2String) {
-    return {
-      date1: convertDate(date1String),
-      date2: convertDate(date2String),
-    }
-  }
-
-  function convertDate(dateString) {
-    const farInTheFutureDate = Date.parse('3000-01-01')
-    if (valueIsSet(dateString)) {
-      let convertedDate = Date.parse(dateString)
-      if (isNaN(convertedDate)) {
-        convertedDate = farInTheFutureDate
-      }
-      return convertedDate
-    }
-    return farInTheFutureDate
-  }
-
-  function isSortDataTypeADate(dataType) {
-    return dataType && (dataType === 'DATE' || dataType === 'DATE_ON_FIRST_LINE')
-  }
-
-  function getClickedColumn(columnIndex) {
-    let clickedColumn = {
-      columnIndex: columnIndex,
-      columnDataType: 'string',
-    }
-    const currentTableDTO = PersistentSortOrder.fetchCurrentTablePersistentIdDTO()
-    if (currentTableDTO) {
-      const matchingColumns = currentTableDTO.currentTableColumns.filter(
-        column => column.columnIndex.toString() === columnIndex
-      )
-      if (matchingColumns.length > 0) {
-        clickedColumn = matchingColumns[0]
-      }
-    }
-    return clickedColumn
-  }
-
-  MOJFrontend.SortableTable.prototype.sort = function (rows, columnIndex, sortDirection) {
-    const clickedColumn = getClickedColumn(columnIndex, sortDirection)
-    const sortDataTypeIsDate = isSortDataTypeADate(clickedColumn.columnDataType)
-    var newRows = rows.sort(
-      $.proxy(function (rowA, rowB) {
-        const tdA = $(rowA).find('td,th').eq(columnIndex)
-        const tdB = $(rowB).find('td,th').eq(columnIndex)
-        const valueA = this.getCellValue(tdA)
-        const valueB = this.getCellValue(tdB)
-        if (sortDirection === 'ascending') {
-          if (sortDataTypeIsDate) {
-            return sortDateAsc(valueA, valueB)
-          } else {
-            return sortStringAsc(valueA, valueB)
-          }
-        } else {
-          if (sortDataTypeIsDate) {
-            return sortDateDesc(valueA, valueB)
-          } else {
-            return sortStringDesc(valueA, valueB)
-          }
-        }
-      }, this)
-    )
-    return newRows
-  }
-  SortableTable.prototype.constructor = SortableTable
-
-  Array.from(tables).forEach(function (table) {
-    new SortableTable(table)
     PersistentSortOrder.activate(table)
   })
 })

--- a/assets/sass/_widgets.scss
+++ b/assets/sass/_widgets.scss
@@ -193,6 +193,12 @@ $unavailable-score-background-colour: #ffffff;
   color: $unavailable-score-colour;
 }
 
+#practitioners-table {
+  thead th {
+    white-space: nowrap;
+  }
+}
+
 .crn-lookup-results {
   background-color: govuk-colour('white');
 

--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -273,11 +273,5 @@ p.capacity-notes-screen
 .workload-inline span
   white-space: nowrap
 
-#practitioners-table thead th[aria-sort] button
-  padding-right: 16px
 
-#practitioners-table thead th[aria-sort] button svg
-  position: absolute
-  right: 0
-  top: 0.15em
 

--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -209,13 +209,13 @@ p.capacity-notes-screen
   color: #1D70B8
   background-color: #ffffff
 
-#govuk-recipient-list 
+#govuk-recipient-list
   padding-left: 0
 
   li
     list-style: none
     margin-left: 0
-  
+
   li:not(:first-of-type)
     border-bottom: 1px solid #CECECE
     margin-bottom: 5px
@@ -226,10 +226,10 @@ p.capacity-notes-screen
     justify-content: space-between
     margin-bottom: 5px
 
-#govuk-saved-emails-list 
+#govuk-saved-emails-list
   padding-left: 0
 
-  li 
+  li
     list-style: none
     margin-left: 0
 
@@ -251,7 +251,7 @@ p.capacity-notes-screen
   flex-direction: column
   align-items: center
 
-  &::before 
+  &::before
     content: ""
     display: block
     margin-bottom: 10px
@@ -272,3 +272,12 @@ p.capacity-notes-screen
 
 .workload-inline span
   white-space: nowrap
+
+#practitioners-table thead th[aria-sort] button
+  padding-right: 16px
+
+#practitioners-table thead th[aria-sort] button svg
+  position: absolute
+  right: 0
+  top: 0.15em
+

--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -46,9 +46,6 @@
 .moj-add-another__item .govuk-form-group--error
     clear: both
 
-.moj-notification-badge
-  padding-top: 3px
-
 .moj-scrollable-pane
   overflow-x: auto
 

--- a/integration_tests/integration/helper/sort-helper.ts
+++ b/integration_tests/integration/helper/sort-helper.ts
@@ -8,20 +8,19 @@ export const sortDataAndAssertSortExpectations = (
   sortExpectations: Array<ColumnSortExpectations>,
   isMultiTabTable: boolean,
 ) => {
+  const normaliseHeaderText = (headerText: string) => headerText.replace(/\s+/g, ' ').trim()
+  const getTargetTable = () => (isMultiTabTable === true ? cy.get('table').eq(0) : cy.get('table').first())
+
   let columnNumber = firstSortableColumnNumber
   sortExpectations.forEach(columnSortExpectation => {
-    if (isMultiTabTable === true) {
-      cy.get('table')
-        .eq(0)
-        .within(() => cy.contains('button', columnSortExpectation.columnHeaderName).click())
-    } else {
-      cy.get('table').within(() => cy.contains('button', columnSortExpectation.columnHeaderName).click())
-    }
+    getTargetTable().within(() => cy.contains('button', columnSortExpectation.columnHeaderName).click())
+
     // check the clicked heading is sorted and all others are not
-    cy.get('thead')
+    getTargetTable()
+      .find('thead')
       .find('th')
       .each($el => {
-        const sort = $el.text() === columnSortExpectation.columnHeaderName ? 'ascending' : 'none'
+        const sort = normaliseHeaderText($el.text()) === columnSortExpectation.columnHeaderName ? 'ascending' : 'none'
         cy.wrap($el).should('have.attr', { 'aria-sort': sort })
       })
 
@@ -29,7 +28,8 @@ export const sortDataAndAssertSortExpectations = (
     let rowNumber = 0
     columnSortExpectation.orderedData.forEach(expectedData => {
       if (expectedData) {
-        cy.get(`tr td:nth-child(${columnNumber})`) // gets the 1st column
+        getTargetTable()
+          .find(`tr td:nth-child(${columnNumber})`) // gets the requested column
           .eq(rowNumber) // grabs the 2nd row of that column
           .contains(expectedData) // asserts expectedColumnValue
       }
@@ -37,32 +37,21 @@ export const sortDataAndAssertSortExpectations = (
     })
 
     // clicking again sorts in the other direction
-    if (isMultiTabTable === true) {
-      cy.get('table')
-        .eq(0)
-        .within(() => cy.contains('button', columnSortExpectation.columnHeaderName).click())
-      cy.get('table')
-        .eq(0)
-        .within(() =>
-          cy
-            .contains('button', columnSortExpectation.columnHeaderName)
-            .should('have.attr', { 'aria-sort': 'descending' }),
-        )
-    } else {
-      cy.get('table').within(() => cy.contains('button', columnSortExpectation.columnHeaderName).click())
-      cy.get('table').within(() =>
-        cy
-          .contains('button', columnSortExpectation.columnHeaderName)
-          .should('have.attr', { 'aria-sort': 'descending' }),
-      )
-    }
+    getTargetTable().within(() => cy.contains('button', columnSortExpectation.columnHeaderName).click())
+    getTargetTable().within(() =>
+      cy
+        .contains('th[aria-sort] button', columnSortExpectation.columnHeaderName)
+        .parent('th')
+        .should('have.attr', { 'aria-sort': 'descending' }),
+    )
 
     // checks data for column is sorted descending
     rowNumber = 0
-    const orderedDataDescending = columnSortExpectation.orderedData.reverse()
+    const orderedDataDescending = [...columnSortExpectation.orderedData].reverse()
     orderedDataDescending.forEach(expectedData => {
       if (expectedData) {
-        cy.get(`tr td:nth-child(${columnNumber})`) // gets the 1st column
+        getTargetTable()
+          .find(`tr td:nth-child(${columnNumber})`) // gets the requested column
           .eq(rowNumber) // grabs the 2nd row of that column
           .contains(expectedData) // asserts expectedColumnValue
       }

--- a/integration_tests/support/commands.js
+++ b/integration_tests/support/commands.js
@@ -3,13 +3,19 @@ Cypress.Commands.add('signIn', (options = { failOnStatusCode: true }) => {
   cy.task('getSignInUrl').then(url => cy.visit(url, options))
 })
 
+const normaliseHeaderText = value =>
+  value
+    .replace(/\r?\n|\r|\n/g, ' ')
+    .replace(/\s{2,}/g, ' ')
+    .trim()
+
 const getTable = (subject, options = {}) => {
   if (subject.get().length > 1) {
     throw new Error(`Selector "${subject.selector}" returned more than 1 element.`)
   }
 
   const tableElement = subject.get()[0]
-  const headers = [...tableElement.querySelectorAll('thead th')].map(e => e.textContent.replace(/\s/g, ' '))
+  const headers = [...tableElement.querySelectorAll('thead th')].map(e => normaliseHeaderText(e.textContent))
 
   const rows = [...tableElement.querySelectorAll('tbody tr')].map(row => {
     return [...row.querySelectorAll('td, th')].map(e => e.textContent.replace(/\r?\n|\r|\n/g, '').trim())

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@babel/traverse": "7.28.3",
         "@flipt-io/flipt-client-js": "^0.2.0",
-        "@ministryofjustice/frontend": "5.2.0",
+        "@ministryofjustice/frontend": "^9.0.0",
         "@ministryofjustice/hmpps-probation-frontend-components": "1.1.0",
         "accessible-autocomplete": "3.0.1",
         "agentkeepalive": "4.6.0",
@@ -29,7 +29,7 @@
         "dayjs": "1.11.13",
         "express": "5.1.0",
         "express-session": "1.18.2",
-        "govuk-frontend": "5.11.1",
+        "govuk-frontend": "^6.0.0",
         "helmet": "8.1.0",
         "http-errors": "2.0.0",
         "jquery": "3.7.1",
@@ -1658,15 +1658,15 @@
       }
     },
     "node_modules/@ministryofjustice/frontend": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-5.2.0.tgz",
-      "integrity": "sha512-qBTeezU8CGfjn4sIqjlZHrK8BPDlJVWzxB0lG1rkm0xlUk7ipp4rQcfvDh9/0+A4YCYpBbldUpDBf7TLfd3pVw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-9.0.0.tgz",
+      "integrity": "sha512-R63EvHq//lONAhpUfZCMfxlUHoysDx5Hc6mi9EEV+sfVGm2spGV52PJAkYCYAc3bhTaTiJDtEM+PXgJm0iTWvQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
       },
       "peerDependencies": {
-        "govuk-frontend": "^5.8.0",
+        "govuk-frontend": "^6.0.0",
         "moment": "2.30.1"
       }
     },
@@ -7317,9 +7317,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.11.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.11.1.tgz",
-      "integrity": "sha512-hJJFpaer4MZLvz/2F9RZ7xZ6FqlzpxL9aw6YWOGK3F1tn419xj2WcVXwOC8Bcj/dc/LanknbWJDGkb+IdkuhTQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.4.0.tgz",
+      "integrity": "sha512-jU3oaVFXqK1yDVIdZs1YZ6JD7YDB4PFUHF3rFMWJye9ArImp42F9wCsFzzB1+udjuzGCryJGcHHbBQ5HY+8rqQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "@babel/traverse": "7.28.3",
         "@flipt-io/flipt-client-js": "^0.2.0",
-        "@ministryofjustice/frontend": "1.8.1",
-        "@ministryofjustice/hmpps-probation-frontend-components": "1.0.0",
+        "@ministryofjustice/frontend": "5.2.0",
+        "@ministryofjustice/hmpps-probation-frontend-components": "1.1.0",
         "accessible-autocomplete": "3.0.1",
         "agentkeepalive": "4.6.0",
         "applicationinsights": "2.9.8",
@@ -1658,26 +1658,16 @@
       }
     },
     "node_modules/@ministryofjustice/frontend": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-1.8.1.tgz",
-      "integrity": "sha512-HNl8XXbNje/NtQRlGM57CTLlAGBTW+ziGTBkxXHDn7VauKNz418PnErDlKRWeaHIyc6V9twI5EbOj4lFCsvasw==",
-      "dependencies": {
-        "govuk-frontend": "^3.0.0 || ^4.0.0",
-        "moment": "^2.27.0"
-      },
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-5.2.0.tgz",
+      "integrity": "sha512-qBTeezU8CGfjn4sIqjlZHrK8BPDlJVWzxB0lG1rkm0xlUk7ipp4rQcfvDh9/0+A4YCYpBbldUpDBf7TLfd3pVw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
       },
       "peerDependencies": {
-        "jquery": "^3.6.0"
-      }
-    },
-    "node_modules/@ministryofjustice/frontend/node_modules/govuk-frontend": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.9.0.tgz",
-      "integrity": "sha512-zfX+GBUKpWBeV6JwCIawEuI8VRWlskH8Ok8aNUjKOvzo3zIaNbcrv4IOwgy+oSnMoGh67Eeh+vb7+9GFxN2fNg==",
-      "engines": {
-        "node": ">= 4.2.0"
+        "govuk-frontend": "^5.8.0",
+        "moment": "2.30.1"
       }
     },
     "node_modules/@ministryofjustice/hmpps-npm-script-allowlist": {
@@ -1698,24 +1688,24 @@
       }
     },
     "node_modules/@ministryofjustice/hmpps-probation-frontend-components": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-probation-frontend-components/-/hmpps-probation-frontend-components-1.0.0.tgz",
-      "integrity": "sha512-udC8X6iyuTESSXSmuOrVhL5Hy2xujVyMaCGtERobV2WwjNCdN0Yem3gUwG0c2Gb1qV8clnSK5u+BdsANSmb3Pg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-probation-frontend-components/-/hmpps-probation-frontend-components-1.1.0.tgz",
+      "integrity": "sha512-cD726vie4D2D48I/AVkQPuV08vI9g1vb/eeloMEtFZN7fkaWDcN9FjnrJZDjGytkaZ5XmdZr/Muk7GeZlvH9OA==",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "22.12.0",
+        "@types/node": "22.20.1",
         "@types/nunjucks": "^3.2.6",
         "nunjucks": "^3.2.4",
         "superagent": "^9.0.2"
       }
     },
     "node_modules/@ministryofjustice/hmpps-probation-frontend-components/node_modules/@types/node": {
-      "version": "22.12.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.12.0.tgz",
-      "integrity": "sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@ministryofjustice/hmpps-probation-frontend-components/node_modules/superagent": {
@@ -1738,12 +1728,6 @@
       "engines": {
         "node": ">=14.18.0"
       }
-    },
-    "node_modules/@ministryofjustice/hmpps-probation-frontend-components/node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "license": "MIT"
     },
     "node_modules/@mswjs/interceptors": {
       "version": "0.39.6",
@@ -13467,7 +13451,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unique-filename": {

--- a/package.json
+++ b/package.json
@@ -98,8 +98,8 @@
   "dependencies": {
     "@babel/traverse": "7.28.3",
     "@flipt-io/flipt-client-js": "^0.2.0",
-    "@ministryofjustice/frontend": "1.8.1",
-    "@ministryofjustice/hmpps-probation-frontend-components": "1.0.0",
+    "@ministryofjustice/frontend": "5.2.0",
+    "@ministryofjustice/hmpps-probation-frontend-components": "1.1.0",
     "accessible-autocomplete": "3.0.1",
     "agentkeepalive": "4.6.0",
     "applicationinsights": "2.9.8",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
   "dependencies": {
     "@babel/traverse": "7.28.3",
     "@flipt-io/flipt-client-js": "^0.2.0",
-    "@ministryofjustice/frontend": "5.2.0",
+    "@ministryofjustice/frontend": "^9.0.0",
     "@ministryofjustice/hmpps-probation-frontend-components": "1.1.0",
     "accessible-autocomplete": "3.0.1",
     "agentkeepalive": "4.6.0",
@@ -116,7 +116,7 @@
     "dayjs": "1.11.13",
     "express": "5.1.0",
     "express-session": "1.18.2",
-    "govuk-frontend": "5.11.1",
+    "govuk-frontend": "^6.0.0",
     "helmet": "8.1.0",
     "http-errors": "2.0.0",
     "jquery": "3.7.1",

--- a/server/app.ts
+++ b/server/app.ts
@@ -3,7 +3,7 @@ import express from 'express'
 import path from 'path'
 import createError from 'http-errors'
 
-import pdsComponents from '@ministryofjustice/hmpps-probation-frontend-components'
+import pdsComponents from '@ministryofjustice/hmpps-probation-frontend-components/dist/src'
 
 import nunjucksSetup from './utils/nunjucksSetup'
 import errorHandler from './errorHandler'

--- a/server/controllers/data/UnallocatedCase.ts
+++ b/server/controllers/data/UnallocatedCase.ts
@@ -22,6 +22,8 @@ export default class UnallocatedCase {
 
   primaryInitialAppointment: string
 
+  initialAppointmentSortValue: string
+
   secondaryInitialAppointment: string
 
   initialAppointment: InitialAppointment
@@ -98,11 +100,13 @@ export default class UnallocatedCase {
   setInitialAppointment(initialAppointment: InitialAppointment, caseType: string, sentenceLength: string): void {
     if (caseType === 'CUSTODY' || caseType === 'LICENSE') {
       this.primaryInitialAppointment = 'Not needed'
+      this.initialAppointmentSortValue = this.primaryInitialAppointment
       this.secondaryInitialAppointment = 'Custody case'
       if (sentenceLength) {
         this.secondaryInitialAppointment += ` (${sentenceLength})`
       }
     } else if (initialAppointment?.date) {
+      this.initialAppointmentSortValue = initialAppointment.date
       this.primaryInitialAppointment = `${dayjs(initialAppointment.date).format(config.dateFormat)}`
       if (initialAppointment.staff?.name?.combinedName !== 'Unallocated Staff') {
         this.secondaryInitialAppointment = initialAppointment.staff?.name?.combinedName
@@ -111,6 +115,7 @@ export default class UnallocatedCase {
       }
     } else {
       this.primaryInitialAppointment = 'Not found'
+      this.initialAppointmentSortValue = this.primaryInitialAppointment
       this.secondaryInitialAppointment = 'Check with your team'
     }
   }

--- a/server/controllers/data/UnallocatedCase.ts
+++ b/server/controllers/data/UnallocatedCase.ts
@@ -18,6 +18,8 @@ export default class UnallocatedCase {
 
   handoverDate: string
 
+  handoverDateFormatted: string
+
   primaryInitialAppointment: string
 
   secondaryInitialAppointment: string
@@ -85,9 +87,11 @@ export default class UnallocatedCase {
 
   setHandoverDate(handoverDate: string) {
     if (handoverDate) {
-      this.handoverDate = `${dayjs(handoverDate).format(config.dateFormat)}`
+      this.handoverDate = handoverDate
+      this.handoverDateFormatted = `${dayjs(handoverDate).format(config.dateFormat)}`
     } else {
       this.handoverDate = 'N/A'
+      this.handoverDateFormatted = 'N/A'
     }
   }
 

--- a/server/middleware/setUpAuthentication.ts
+++ b/server/middleware/setUpAuthentication.ts
@@ -2,7 +2,7 @@ import type { Router } from 'express'
 import express from 'express'
 import passport from 'passport'
 import flash from 'connect-flash'
-import pdsComponents from '@ministryofjustice/hmpps-probation-frontend-components'
+import pdsComponents from '@ministryofjustice/hmpps-probation-frontend-components/dist/src'
 import config from '../config'
 import auth from '../authentication/auth'
 

--- a/server/views/pages/find-unallocated-cases.njk
+++ b/server/views/pages/find-unallocated-cases.njk
@@ -74,7 +74,7 @@
       { text: (item.sentenceDate | dateFormat), attributes: {
           "data-sort-value": item.sentenceDate
       } },
-      { text: item.handoverDate, attributes: { "data-sort-value": item.handoverDate } },
+      { text: item.handoverDateFormatted, attributes: { "data-sort-value": item.handoverDate } },
       {
           colspan: "2",
           text: 'This case is sitting in a different area, and the transfer process must be completed in NDelius before it can be allocated through the service. You can still review the case details.', attributes: { "data-sort-value": item.tierOrder }
@@ -90,7 +90,7 @@
             { text: (item.sentenceDate | dateFormat), attributes: {
                 "data-sort-value": item.sentenceDate
             } },
-            { text: item.handoverDate, attributes: { "data-sort-value": item.handoverDate } },
+            { text: item.handoverDateFormatted, attributes: { "data-sort-value": item.handoverDate } },
             {
                 text: doubleCell(item.primaryInitialAppointment,item.secondaryInitialAppointment, 'maw-secondary' ),
                 attributes: { "data-sort-value": item.primaryInitialAppointment }

--- a/server/views/pages/find-unallocated-cases.njk
+++ b/server/views/pages/find-unallocated-cases.njk
@@ -93,7 +93,7 @@
             { text: item.handoverDateFormatted, attributes: { "data-sort-value": item.handoverDate } },
             {
                 text: doubleCell(item.primaryInitialAppointment,item.secondaryInitialAppointment, 'maw-secondary' ),
-                attributes: { "data-sort-value": item.primaryInitialAppointment }
+                attributes: { "data-sort-value": item.initialAppointmentSortValue }
             },
             { text: doubleCell(item.primaryStatus, item.secondaryStatus, 'govuk-body-s')}
         ] -%}

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -102,7 +102,7 @@
                   f = !0, t = h, s = function () {
                   var e = {},
                     t = d.connectionString;
-                  if (t) 
+                  if (t)
                     for (var n = t.split(";"), a = 0; a < n.length; a++) {
                       var i = n[a].split("=");
                       2 === i.length && (e[i[0][b]()] = i[1])
@@ -147,7 +147,7 @@
                 function (e, t) {
                   if (JSON) {
                     var n = T.fetch;
-                    if (n && !y.useXhr) 
+                    if (n && !y.useXhr)
                       n(t, {
                         method: N,
                         body: JSON.stringify(e),
@@ -194,7 +194,7 @@
               m.cookie = l.cookie
             } catch (p) {}
             function t(e) {
-              for (; e.length;) 
+              for (; e.length;)
                 !function (t) {
                   m[t] = function () {
                     var e = arguments;
@@ -405,9 +405,10 @@
     {% endblock %}
 
     {% block bodyEnd %}
-      <script type="module" src="/assets/govuk/govuk-frontend.min.js"></script>
-      <script type="module" src="/assets/govukFrontendInit.js"></script>
-      <script src="/assets/moj/all.js"></script>
+      <script src="/assets/govuk/all.bundle.js"></script>
+      <script src="/assets/govukFrontendInit.js"></script>
+      <script src="/assets/moj/all.bundle.js"></script>
+      <script src="/assets/moj/components/sortable-table/sortable-table.bundle.js"></script>
       <script src="/assets/naturalSortableTable.js"></script>
       <script src="/assets/mojSortableTable.js"></script>
       <script src="/assets/mojFrontendInit.js"></script>


### PR DESCRIPTION
So this has been a real pain - to fix the broken PDS header we needed to be using MOJ Frontend of at least 5.2.0, which meant a big upgrade. I initially thought that nothing was broken, but then realised that table sorting actually was, but this is fixed now and also still persists.
This was due to MOJ Frontend 5.2.0 changed from jQuery-based prototype inheritance to ES6 classes. The current mojSortableTable.js used old jQuery-style prototype extension which didn't work with ES6 classes.

<img width="1385" height="426" alt="image" src="https://github.com/user-attachments/assets/9564bec1-3b2a-4222-8c15-8ecaac4fff8a" />

<img width="1324" height="379" alt="image" src="https://github.com/user-attachments/assets/0ae2251b-f33e-43d9-a5e4-3ee9c36f46a0" />

I have also upgraded `@ministryofjustice/hmpps-probation-frontend-components` to `1.1.0` and the header is now displaying correctly.

I've upgraded MOJ Frontend to 9.0.0 and Gov Frontend to 6.0, the only change I've noticed was the red notification badge in the nav menu looked weird but we had added padding to the top of it, so I've removed that and now looks as it should looking at the MOJ design system:
<img width="934" height="640" alt="image" src="https://github.com/user-attachments/assets/603abb36-0884-4244-b218-7c317bea7c72" />

So the page now looks like this:
<img width="1438" height="731" alt="image" src="https://github.com/user-attachments/assets/e9af3210-aa3c-4247-acda-4ecbfdb82de6" />
